### PR TITLE
Add Postgres URL function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ This repository will build different docker images for different services. For t
 ```
 
 - `./cmd` contains the entry point boilerplate for each service.
-- `./pkg/functions` contains the actual logic for the function. Each transform should be in its own package.
+- `./functions` contains the actual logic for the function. Each transform should be in its own package.
+- `./runtime` contains a library with helper methods which helps with adding new functions. 
+
+Check out the docs to understand how functions from this repository work.
 
 ## Add a new function
 
@@ -34,11 +37,11 @@ The framework is designed to easily add new composition functions to any AppCat 
 
 To add a new function to PostgreSQL by VSHN:
 
-- Create a new package under `./pkg/functions/vshn-postgres-func`
+- Create a new package under `./functions/vshn-postgres-func`
 - Add the transform function to the list in `./cmd/vshn-postgres-func`
-- implement the actual `transform()` function by using the helper functions from `io.go`
+- implement the actual `Transform()` function by using the helper functions from `runtime/runtime.go`
 
-This architecture allows us to run all the functions with a single command. But for debugging and development purpose it's possible to run each function seperately, by using the `--function` flag.
+This architecture allows us to run all the functions with a single command. But for debugging and development purpose it's possible to run each function separately, by using the `--function` flag.
 
 ## Manually testing a function
 To test a function you can leverage the FunctionIO file in the `./test` folder.

--- a/cmd/vshn-postgres-func/main.go
+++ b/cmd/vshn-postgres-func/main.go
@@ -12,7 +12,7 @@ import (
 
 var postgresFunctions = []runtime.Transform[vshnv1.VSHNPostgreSQL, *vshnv1.VSHNPostgreSQL]{
 	{
-		Name:          "dummy",
+		Name:          "url-connection-detail",
 		TransformFunc: vp.Transform,
 	},
 }

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -12,4 +12,4 @@
 //* xref:references/example.adoc[Example Reference]
 
 .Explanation
-//* xref:explanations/example.adoc[Example Explanation]
+* xref:explanations/vshn-postgres.adoc[VSHN Postgres Functions]

--- a/docs/modules/ROOT/pages/explanations/vshn-postgres.adoc
+++ b/docs/modules/ROOT/pages/explanations/vshn-postgres.adoc
@@ -1,0 +1,10 @@
+= VSHN Postgres Functions
+
+The set of functions applied to a VSHN Postgres composition.
+
+== Function URL-CONNECTION-DETAILS
+
+The function URL-CONNECTION-DETAILS adds a new `POSTGRES_URL` entry in  the connection detail of the composite. The value is defined as `postgres://user:password@host:port/db`. Once it is executed the client has access to the URL of its database via connection secret.
+
+
+

--- a/functions/vshn-postgres-func/url.go
+++ b/functions/vshn-postgres-func/url.go
@@ -3,16 +3,77 @@ package vshnpostgres
 import (
 	"context"
 	"fmt"
-	"github.com/vshn/appcat-comp-functions/runtime"
-
+	"github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
 	"github.com/go-logr/logr"
+	"github.com/vshn/appcat-comp-functions/runtime"
 	vshnv1 "github.com/vshn/component-appcat/apis/vshn/v1"
+	v1 "k8s.io/api/core/v1"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 )
+
+var (
+	// PostgresqlHost is env variable in the connection secret
+	PostgresqlHost = "POSTGRESQL_HOST"
+	// PostgresqlUser is env variable in the connection secret
+	PostgresqlUser = "POSTGRESQL_USER"
+	// PostgresqlPassword is env variable in the connection secret
+	PostgresqlPassword = "POSTGRESQL_PASSWORD"
+	// PostgresqlPort is env variable in the connection secret
+	PostgresqlPort = "POSTGRESQL_PORT"
+	// PostgresqlDb is env variable in the connection secret
+	PostgresqlDb = "POSTGRESQL_DB"
+	// PostgresqlUrl is env variable in the connection secret
+	PostgresqlUrl = "POSTGRESQL_URL"
+)
+
+// connectionSecretResourceName is the resource name defined in the composition
+// This name is different from metadata.name of the same resource
+// The value is hardcoded in the composition for each resource and due to crossplane limitation
+// it cannot be matched to the metadata.name
+var connectionSecretResourceName = "connection"
 
 // Transform changes the desired state of a FunctionIO
 func Transform(ctx context.Context, log logr.Logger, iof *runtime.Runtime, comp *vshnv1.VSHNPostgreSQL) (*vshnv1.VSHNPostgreSQL, error) {
+	// Wait for the next reconciliation in case instance namespace is missing
+	if comp.Status.InstanceNamespace == "" {
+		log.Info("Composite is missing instance namespace, skipping transformation")
+		return comp, nil
+	}
 
-	fmt.Println("I'm a dummy!")
+	log.Info("Getting connection secret from managed kubernetes object")
+	s := &v1.Secret{}
+
+	err := iof.GetFromKubeObject(ctx, s, connectionSecretResourceName)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get connection secret object: %w", err)
+	}
+
+	log.Info("Setting POSTRESQL_URL env variable into connection secret")
+	val := getPostgresURL(ctx, s)
+
+	iof.Desired.Composite.ConnectionDetails =
+		append(iof.Desired.Composite.ConnectionDetails, v1alpha1.ExplicitConnectionDetail{
+			Name:  PostgresqlUrl,
+			Value: val,
+		})
 
 	return comp, nil
+}
+
+func getPostgresURL(ctx context.Context, s *v1.Secret) string {
+	log := controllerruntime.LoggerFrom(ctx)
+
+	user := string(s.Data[PostgresqlUser])
+	pwd := string(s.Data[PostgresqlPassword])
+	host := string(s.Data[PostgresqlHost])
+	port := string(s.Data[PostgresqlPort])
+	db := string(s.Data[PostgresqlDb])
+
+	// The values are still missing, wait for the next reconciliation
+	if user == "" || pwd == "" || host == "" || port == "" || db == "" {
+		log.Info("User, pass, host, port or db value is missing from connection secret, skipping transformation")
+		return ""
+	}
+
+	return "postgres://" + user + ":" + pwd + "@" + host + ":" + port + "/" + db
 }

--- a/functions/vshn-postgres-func/url_test.go
+++ b/functions/vshn-postgres-func/url_test.go
@@ -1,0 +1,148 @@
+//go:build integration
+
+package vshnpostgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/vshn/appcat-comp-functions/runtime"
+	vshnv1 "github.com/vshn/component-appcat/apis/vshn/v1"
+	v1 "k8s.io/api/core/v1"
+	"os"
+	"path/filepath"
+	"sigs.k8s.io/yaml"
+	"strings"
+	"testing"
+)
+
+func TestTransform_NoInstanceNamespace(t *testing.T) {
+	expectIo := getFunctionFromFile("01_expected_no-instance-namespace.yaml")
+	expectVpu := &vshnv1.VSHNPostgreSQL{}
+	expectComp := getCompositeFromIO(expectIo, expectVpu)
+
+	t.Run("WhenNoInstance_ThenNoErrorAndNoChanges", func(t *testing.T) {
+
+		//Given
+		io := getFunctionFromFile("01_input_no-instance-namespace.yaml")
+		vpu := &vshnv1.VSHNPostgreSQL{}
+		comp := getCompositeFromIO(io, vpu)
+		ctx := context.Background()
+		log := logr.FromContextOrDiscard(ctx)
+
+		// When
+		comp, err := Transform(ctx, log, io, comp)
+
+		// Then
+		assert.NoError(t, err)
+		assert.Equal(t, expectIo, io)
+		assert.Equal(t, expectComp, comp)
+	})
+}
+
+func TestTransform(t *testing.T) {
+	expectURL := "postgres://postgres:639b-9076-4de6-a35@" +
+		"pgsql-gc9x4.vshn-postgresql-pgsql-gc9x4.svc.cluster.local:5432/postgres"
+
+	t.Run("WhenNormalIO_ThenAddPostgreSQLUrl", func(t *testing.T) {
+
+		//Given
+		io := getFunctionFromFile("02_input_function-io.yaml")
+		vpu := &vshnv1.VSHNPostgreSQL{}
+		comp := getCompositeFromIO(io, vpu)
+		ctx := context.Background()
+		log := logr.FromContextOrDiscard(ctx)
+
+		// When
+		actualComp, err := Transform(ctx, log, io, comp)
+
+		// Then
+		assert.NoError(t, err)
+		assert.Equal(t, expectURL, io.Desired.Composite.ConnectionDetails[0].Value)
+		assert.Equal(t, comp, actualComp)
+	})
+}
+
+func TestGetPostgresURL(t *testing.T) {
+	tests := map[string]struct {
+		secret    *v1.Secret
+		expectUrl string
+	}{
+		"WhenMissingUserAndPortThenReturnNoUrlInSecret": {
+			secret: &v1.Secret{
+				Data: map[string][]byte{
+					PostgresqlPassword: []byte("test"),
+					PostgresqlDb:       []byte("db-test"),
+					PostgresqlHost:     []byte("localhost"),
+				},
+			},
+			expectUrl: "",
+		},
+		"WhenMissingPasswordThenReturnNoUrlInSecret": {
+			secret: &v1.Secret{
+				Data: map[string][]byte{
+					PostgresqlDb:   []byte("db-test"),
+					PostgresqlHost: []byte("localhost"),
+					PostgresqlUser: []byte("user"),
+					PostgresqlPort: []byte("5432"),
+				},
+			},
+			expectUrl: "",
+		},
+		"WhenDataThenReturnSecretWithUrl": {
+			secret: &v1.Secret{
+				Data: map[string][]byte{
+					PostgresqlPassword: []byte("test"),
+					PostgresqlDb:       []byte("db-test"),
+					PostgresqlHost:     []byte("localhost"),
+					PostgresqlUser:     []byte("user"),
+					PostgresqlPort:     []byte("5432"),
+				},
+				StringData: map[string]string{
+					"place": "test",
+				},
+			},
+			expectUrl: "postgres://user:test@localhost:5432/db-test",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			// Given
+			ctx := context.Background()
+
+			// When
+			url := getPostgresURL(ctx, tc.secret)
+
+			// Then
+			assert.Equal(t, tc.expectUrl, url)
+		})
+	}
+}
+
+func getFunctionFromFile(file string) *runtime.Runtime {
+	p, _ := filepath.Abs(".")
+	before, _, _ := strings.Cut(p, "/functions")
+	dat, err := os.ReadFile(before + "/test/transforms/vshn-postgres/url/" + file)
+	if err != nil {
+		fmt.Errorf("cannot read test file %s: %w", file, err)
+	}
+
+	funcIO := runtime.Runtime{}
+	err = yaml.Unmarshal(dat, &funcIO)
+	if err != nil {
+		fmt.Errorf("cannot umarshal test file %s: %w", file, err)
+	}
+
+	return &funcIO
+}
+
+func getCompositeFromIO[T any](io *runtime.Runtime, obj *T) *T {
+	err := json.Unmarshal(io.Observed.Composite.Resource.Raw, obj)
+	if err != nil {
+		os.Exit(1)
+	}
+	return obj
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/crossplane/crossplane-runtime v0.19.2
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
+	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli/v2 v2.23.7
 	github.com/vshn/component-appcat/apis v0.0.0-20230323120435-814284eb8a95
 	go.uber.org/zap v1.24.0
@@ -46,6 +47,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.6.1 // indirect
 	github.com/onsi/gomega v1.24.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -52,7 +52,7 @@ func getFunctionIO(ctx context.Context) (*Runtime, error) {
 	funcIO := Runtime{}
 	err = yaml.Unmarshal(x, &funcIO)
 	if err != nil {
-		return nil, fmt.Errorf("cannot unmarshall function io: %w", err)
+		return nil, fmt.Errorf("cannot unmarshal function io: %w", err)
 	}
 
 	return &funcIO, nil
@@ -76,7 +76,7 @@ func (in *Runtime) GetFromKubeObject(ctx context.Context, o client.Object, kon s
 	}
 	err := in.get(ko, kon)
 	if err != nil {
-		return fmt.Errorf("cannot get unmarshall kubernetes object: %w", err)
+		return fmt.Errorf("cannot get unmarshal kubernetes object: %w", err)
 	}
 
 	log.V(1).Info("Unmarshalling object from kube object", "object type", reflect.TypeOf(o))
@@ -165,7 +165,7 @@ func (in *Runtime) get(obj client.Object, resName string) error {
 		if res.Name == resName {
 			err := yaml.Unmarshal(in.Observed.Resources[i].Resource.Raw, obj)
 			if err != nil {
-				return fmt.Errorf("cannot unmarshall desired resource: %w", err)
+				return fmt.Errorf("cannot unmarshal desired resource: %w", err)
 			}
 
 			// matching by name is not enough, group and kind should match

--- a/test/transforms/vshn-postgres/url/01_expected_no-instance-namespace.yaml
+++ b/test/transforms/vshn-postgres/url/01_expected_no-instance-namespace.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: FunctionIO
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        name: pgsql-gc9x4
+      spec:
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNPostgreSQL
+          name: pgsql
+          namespace: test
+        compositionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io
+        compositionRevisionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
+        compositionUpdatePolicy: Automatic
+        parameters:
+          backup:
+            retention: 6
+            schedule: 0 22 * * *
+          maintenance:
+            dayOfWeek: tuesday
+            timeOfDay: "22:30:00"
+          service:
+            majorVersion: "15"
+          size:
+            cpu: 600m
+            disk: 5Gi
+            memory: 3500Mi
+            plan: standard-2
+        resourceRefs:
+          - apiVersion: kubernetes.crossplane.io/v1alpha1
+            kind: Object
+            name: pgsql-gc9x4-connection
+desired:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        name: pgsql-gc9x4
+      spec:
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNPostgreSQL
+          name: pgsql
+          namespace: test
+        compositionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io
+        compositionRevisionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
+        compositionUpdatePolicy: Automatic
+        parameters:
+          backup:
+            retention: 6
+            schedule: 0 22 * * *
+          maintenance:
+            dayOfWeek: tuesday
+            timeOfDay: "22:30:00"
+          service:
+            majorVersion: "15"
+          size:
+            cpu: 600m
+            disk: 5Gi
+            memory: 3500Mi
+            plan: standard-2
+        resourceRefs:
+          - apiVersion: kubernetes.crossplane.io/v1alpha1
+            kind: Object
+            name: pgsql-gc9x4-connection

--- a/test/transforms/vshn-postgres/url/01_input_no-instance-namespace.yaml
+++ b/test/transforms/vshn-postgres/url/01_input_no-instance-namespace.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: FunctionIO
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        name: pgsql-gc9x4
+      spec:
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNPostgreSQL
+          name: pgsql
+          namespace: test
+        compositionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io
+        compositionRevisionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
+        compositionUpdatePolicy: Automatic
+        parameters:
+          backup:
+            retention: 6
+            schedule: 0 22 * * *
+          maintenance:
+            dayOfWeek: tuesday
+            timeOfDay: "22:30:00"
+          service:
+            majorVersion: "15"
+          size:
+            cpu: 600m
+            disk: 5Gi
+            memory: 3500Mi
+            plan: standard-2
+        resourceRefs:
+          - apiVersion: kubernetes.crossplane.io/v1alpha1
+            kind: Object
+            name: pgsql-gc9x4-connection
+desired:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        name: pgsql-gc9x4
+      spec:
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNPostgreSQL
+          name: pgsql
+          namespace: test
+        compositionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io
+        compositionRevisionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
+        compositionUpdatePolicy: Automatic
+        parameters:
+          backup:
+            retention: 6
+            schedule: 0 22 * * *
+          maintenance:
+            dayOfWeek: tuesday
+            timeOfDay: "22:30:00"
+          service:
+            majorVersion: "15"
+          size:
+            cpu: 600m
+            disk: 5Gi
+            memory: 3500Mi
+            plan: standard-2
+        resourceRefs:
+          - apiVersion: kubernetes.crossplane.io/v1alpha1
+            kind: Object
+            name: pgsql-gc9x4-connection

--- a/test/transforms/vshn-postgres/url/02_input_function-io.yaml
+++ b/test/transforms/vshn-postgres/url/02_input_function-io.yaml
@@ -6,28 +6,13 @@ observed:
       apiVersion: vshn.appcat.vshn.io/v1
       kind: XVSHNPostgreSQL
       metadata:
-        annotations:
-          kubectl.kubernetes.io/last-applied-configuration: |
-            {"apiVersion":"vshn.appcat.vshn.io/v1","kind":"VSHNPostgreSQL","metadata":{"annotations":{},"name":"pgsql","namespace":"glrf-test"},"spec":{"parameters":{"service":{"majorVersion":"15"}},"writeConnectionSecretToRef":{"name":"postgres-creds"}}}
-        creationTimestamp: "2023-03-21T16:52:31Z"
-        finalizers:
-          - composite.apiextensions.crossplane.io
-        generateName: pgsql-
-        generation: 13
-        labels:
-          appuio.io/organization: vshn
-          crossplane.io/claim-name: pgsql
-          crossplane.io/claim-namespace: glrf-test
-          crossplane.io/composite: pgsql-gc9x4
         name: pgsql-gc9x4
-        resourceVersion: "481074263"
-        uid: 0cbf744b-7529-4d33-afe6-26bc5a575f7c
       spec:
         claimRef:
           apiVersion: vshn.appcat.vshn.io/v1
           kind: VSHNPostgreSQL
           name: pgsql
-          namespace: glrf-test
+          namespace: test
         compositionRef:
           name: vshnpostgres.vshn.appcat.vshn.io
         compositionRevisionRef:
@@ -50,149 +35,9 @@ observed:
         resourceRefs:
           - apiVersion: kubernetes.crossplane.io/v1alpha1
             kind: Object
-            name: ns-observer-pgsql-gc9x4
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: vshn-postgresql-pgsql-gc9x4
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-service-rolebinding
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-localca
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-certificate
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-profile
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-pgconf
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-cluster
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
             name: pgsql-gc9x4-connection
-          - apiVersion: appcat.vshn.io/v1
-            kind: XObjectBucket
-            name: pgsql-gc9x4
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-object-storage
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-maintenanceserviceaccount
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-maintenancerole
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-maintenancerolebinding
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-maintenancejob
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-podmonitor
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-prometheusrule
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-network-policy
-        writeConnectionSecretToRef:
-          name: 0cbf744b-7529-4d33-afe6-26bc5a575f7c
-          namespace: syn-crossplane
       status:
-        certificateConditions:
-          - lastTransitionTime: "2023-03-21T16:53:16Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:52:52Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        conditions:
-          - lastTransitionTime: "2023-03-21T16:52:32Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-          - lastTransitionTime: "2023-03-23T09:01:04Z"
-            reason: Available
-            status: "True"
-            type: Ready
-        connectionDetails:
-          lastPublishedTime: "2023-03-21T16:54:36Z"
         instanceNamespace: vshn-postgresql-pgsql-gc9x4
-        localCAConditions:
-          - lastTransitionTime: "2023-03-21T16:53:15Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:52:52Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        namespaceConditions:
-          - lastTransitionTime: "2023-03-21T16:53:14Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:52:51Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        networkPolicyConditions:
-          - lastTransitionTime: "2023-03-21T16:53:24Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:53:00Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        pgclusterConditions:
-          - lastTransitionTime: "2023-03-21T16:53:44Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-23T09:00:30Z"
-            message: 'update failed: cannot apply object: cannot patch object: admission webhook
-            "sgcluster.stackgres-operator.syn-stackgres-operator" denied the request: Decrease
-            of persistent volume size is not supported'
-            reason: ReconcileError
-            status: "False"
-            type: Synced
-        pgconfigConditions:
-          - lastTransitionTime: "2023-03-21T16:53:16Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:52:52Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        profileConditions:
-          - lastTransitionTime: "2023-03-21T16:53:16Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:52:52Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        secretConditions:
-          - lastTransitionTime: "2023-03-21T16:54:07Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-          - lastTransitionTime: "2023-03-21T16:54:07Z"
-            reason: Available
-            status: "True"
-            type: Ready
   resources:
     - name: connection
       resource:
@@ -210,11 +55,12 @@ observed:
                 name: pgsql-connection
                 namespace: vshn-postgresql-pgsql-gc9x4
               data:
-                PPOSTGRESQL_DB: cG9zdGdyZXM=
-                POSTGRESQL_HOST: cGdzcWwtYXBwMS1wcm9kLXpkejRzLnZzaG4tcG9zdGdyZXNxbC1wZ3NxbC1hcHAxLXByb2QtemR6NHMuc3ZjLmNsdXN0ZXIubG9jYWw=
-                POSTGRESQL_PASSWORD: NTY4MC0xNTI2LTRmMGQtYTAw
-                POSTGRESQL_PORT: NTQzMg==
-                POSTGRESQL_USER: cG9zdGdyZXM=
+                POSTGRESQL_PASSWORD: NjM5Yi05MDc2LTRkZTYtYTM1
+              stringData:
+                POSTGRESQL_DB: postgres
+                POSTGRESQL_HOST: pgsql-gc9x4.vshn-postgresql-pgsql-gc9x4.svc.cluster.local
+                POSTGRESQL_PORT: "5432"
+                POSTGRESQL_USER: postgres
           providerConfigRef:
             name: kubernetes
           references:
@@ -222,33 +68,47 @@ observed:
                 apiVersion: v1
                 fieldPath: data.superuser-password
                 kind: Secret
-                name: ""
-                namespace: ""
+                name: final-test
+                namespace: test
               toFieldPath: data.POSTGRESQL_PASSWORD
             - patchesFrom:
                 apiVersion: v1
                 fieldPath: data[ca.crt]
                 kind: Secret
                 name: tls-certificate
-                namespace: ""
+                namespace: test
               toFieldPath: data[ca.crt]
             - patchesFrom:
                 apiVersion: v1
                 fieldPath: data[tls.crt]
                 kind: Secret
                 name: tls-certificate
-                namespace: ""
+                namespace: test
               toFieldPath: data[tls.crt]
             - patchesFrom:
                 apiVersion: v1
                 fieldPath: data[tls.key]
                 kind: Secret
                 name: tls-certificate
-                namespace: ""
+                namespace: test
               toFieldPath: data[tls.key]
           writeConnectionSecretToRef:
-            name: ""
-            namespace: ""
+            name: final-test
+            namespace: test
+        status:
+          atProvider:
+            manifest:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: pgsql-connection
+                namespace: vshn-postgresql-pgsql-gc9x4
+              data:
+                POSTGRESQL_PASSWORD: NjM5Yi05MDc2LTRkZTYtYTM1
+                POSTGRESQL_DB: cG9zdGdyZXM=
+                POSTGRESQL_HOST: cGdzcWwtZ2M5eDQudnNobi1wb3N0Z3Jlc3FsLXBnc3FsLWdjOXg0LnN2Yy5jbHVzdGVyLmxvY2Fs
+                POSTGRESQL_PORT: NTQzMg==
+                POSTGRESQL_USER: cG9zdGdyZXM=
       connectionDetails:
         - fromConnectionSecretKey: ca.crt
           name: ca.crt
@@ -371,28 +231,13 @@ desired:
       apiVersion: vshn.appcat.vshn.io/v1
       kind: XVSHNPostgreSQL
       metadata:
-        annotations:
-          kubectl.kubernetes.io/last-applied-configuration: |
-            {"apiVersion":"vshn.appcat.vshn.io/v1","kind":"VSHNPostgreSQL","metadata":{"annotations":{},"name":"pgsql","namespace":"glrf-test"},"spec":{"parameters":{"service":{"majorVersion":"15"}},"writeConnectionSecretToRef":{"name":"postgres-creds"}}}
-        creationTimestamp: "2023-03-21T16:52:31Z"
-        finalizers:
-          - composite.apiextensions.crossplane.io
-        generateName: pgsql-
-        generation: 13
-        labels:
-          appuio.io/organization: vshn
-          crossplane.io/claim-name: pgsql
-          crossplane.io/claim-namespace: glrf-test
-          crossplane.io/composite: pgsql-gc9x4
         name: pgsql-gc9x4
-        resourceVersion: "481074263"
-        uid: 0cbf744b-7529-4d33-afe6-26bc5a575f7c
       spec:
         claimRef:
           apiVersion: vshn.appcat.vshn.io/v1
           kind: VSHNPostgreSQL
           name: pgsql
-          namespace: glrf-test
+          namespace: test
         compositionRef:
           name: vshnpostgres.vshn.appcat.vshn.io
         compositionRevisionRef:
@@ -415,149 +260,9 @@ desired:
         resourceRefs:
           - apiVersion: kubernetes.crossplane.io/v1alpha1
             kind: Object
-            name: ns-observer-pgsql-gc9x4
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: vshn-postgresql-pgsql-gc9x4
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-service-rolebinding
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-localca
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-certificate
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-profile
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-pgconf
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-cluster
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
             name: pgsql-gc9x4-connection
-          - apiVersion: appcat.vshn.io/v1
-            kind: XObjectBucket
-            name: pgsql-gc9x4
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-object-storage
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-maintenanceserviceaccount
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-maintenancerole
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-maintenancerolebinding
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-maintenancejob
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-podmonitor
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-prometheusrule
-          - apiVersion: kubernetes.crossplane.io/v1alpha1
-            kind: Object
-            name: pgsql-gc9x4-network-policy
-        writeConnectionSecretToRef:
-          name: 0cbf744b-7529-4d33-afe6-26bc5a575f7c
-          namespace: syn-crossplane
       status:
-        certificateConditions:
-          - lastTransitionTime: "2023-03-21T16:53:16Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:52:52Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        conditions:
-          - lastTransitionTime: "2023-03-21T16:52:32Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-          - lastTransitionTime: "2023-03-23T09:01:04Z"
-            reason: Available
-            status: "True"
-            type: Ready
-        connectionDetails:
-          lastPublishedTime: "2023-03-21T16:54:36Z"
         instanceNamespace: vshn-postgresql-pgsql-gc9x4
-        localCAConditions:
-          - lastTransitionTime: "2023-03-21T16:53:15Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:52:52Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        namespaceConditions:
-          - lastTransitionTime: "2023-03-21T16:53:14Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:52:51Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        networkPolicyConditions:
-          - lastTransitionTime: "2023-03-21T16:53:24Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:53:00Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        pgclusterConditions:
-          - lastTransitionTime: "2023-03-21T16:53:44Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-23T09:00:30Z"
-            message: 'update failed: cannot apply object: cannot patch object: admission webhook
-            "sgcluster.stackgres-operator.syn-stackgres-operator" denied the request: Decrease
-            of persistent volume size is not supported'
-            reason: ReconcileError
-            status: "False"
-            type: Synced
-        pgconfigConditions:
-          - lastTransitionTime: "2023-03-21T16:53:16Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:52:52Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        profileConditions:
-          - lastTransitionTime: "2023-03-21T16:53:16Z"
-            reason: Available
-            status: "True"
-            type: Ready
-          - lastTransitionTime: "2023-03-21T16:52:52Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-        secretConditions:
-          - lastTransitionTime: "2023-03-21T16:54:07Z"
-            reason: ReconcileSuccess
-            status: "True"
-            type: Synced
-          - lastTransitionTime: "2023-03-21T16:54:07Z"
-            reason: Available
-            status: "True"
-            type: Ready
   resources:
     - name: connection
       resource:
@@ -588,33 +293,33 @@ desired:
                 apiVersion: v1
                 fieldPath: data.superuser-password
                 kind: Secret
-                name: ""
-                namespace: ""
+                name: final-test
+                namespace: test
               toFieldPath: data.POSTGRESQL_PASSWORD
             - patchesFrom:
                 apiVersion: v1
                 fieldPath: data[ca.crt]
                 kind: Secret
                 name: tls-certificate
-                namespace: ""
+                namespace: test
               toFieldPath: data[ca.crt]
             - patchesFrom:
                 apiVersion: v1
                 fieldPath: data[tls.crt]
                 kind: Secret
                 name: tls-certificate
-                namespace: ""
+                namespace: test
               toFieldPath: data[tls.crt]
             - patchesFrom:
                 apiVersion: v1
                 fieldPath: data[tls.key]
                 kind: Secret
                 name: tls-certificate
-                namespace: ""
+                namespace: test
               toFieldPath: data[tls.key]
           writeConnectionSecretToRef:
-            name: ""
-            namespace: ""
+            name: final-test
+            namespace: test
       connectionDetails:
         - fromConnectionSecretKey: ca.crt
           name: ca.crt


### PR DESCRIPTION
## Summary

* This PR adds FunctionIO URL for VSHN Postgres composition.

### Function URL
The function creates a new env variable POSTGRES_URL in the connection secret resource of the VSHN postgres composition. The data necessary to craft the URL is taken from the same secret, user, password, host, post and database.


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
