### PR TITLE
Pass the specified name to the target secret

### DIFF
--- a/functions/vshn-postgres-func/alerting.go
+++ b/functions/vshn-postgres-func/alerting.go
@@ -128,7 +128,7 @@ func deployAlertmanagerFromTemplate(comp *vshnv1.VSHNPostgreSQL, iof *runtime.Ru
 func deploySecretRef(comp *vshnv1.VSHNPostgreSQL, iof *runtime.Runtime) error {
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "postgresql-alertmanagerconfigsecret",
+			Name:      comp.Spec.Parameters.Monitoring.AlertmanagerConfigSecretRef,
 			Namespace: comp.Status.InstanceNamespace,
 		},
 	}

--- a/functions/vshn-postgres-func/alerting_test.go
+++ b/functions/vshn-postgres-func/alerting_test.go
@@ -9,6 +9,7 @@ import (
 	alertmanagerv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	vshnv1 "github.com/vshn/component-appcat/apis/vshn/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestAddUserAlerting(t *testing.T) {
@@ -85,6 +86,12 @@ func TestGivenConfigRefAndSecretThenExpectOutput(t *testing.T) {
 		alertConfig := &alertmanagerv1alpha1.AlertmanagerConfig{}
 		assert.NoError(t, iof.GetFromDesiredKubeObject(ctx, alertConfig, resName))
 		assert.Equal(t, comp.Status.InstanceNamespace, alertConfig.GetNamespace())
+
+		secretName := "psql-alertmanagerconfigsecret"
+		secret := &v1.Secret{}
+		assert.NoError(t, iof.GetFromDesiredKubeObject(ctx, secret, secretName))
+
+		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigSecretRef, secret.GetName())
 	})
 
 }
@@ -112,5 +119,11 @@ func TestGivenConfigTemplateAndSecretThenExpectOutput(t *testing.T) {
 		assert.NoError(t, iof.GetFromDesiredKubeObject(ctx, alertConfig, resName))
 		assert.Equal(t, comp.Status.InstanceNamespace, alertConfig.GetNamespace())
 		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigSpecTemplate, &alertConfig.Spec)
+
+		secretName := "psql-alertmanagerconfigsecret"
+		secret := &v1.Secret{}
+		assert.NoError(t, iof.GetFromDesiredKubeObject(ctx, secret, secretName))
+
+		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigSecretRef, secret.GetName())
 	})
 }


### PR DESCRIPTION
## Summary

* Previously the name for the alertmanager secret was hardcoded, breaking the alertmanagerConfig

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
