### PR TITLE
Improve runtime library

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,37 +9,41 @@
 [releases]: https://github.com/vshn/appcat-comp-functions/releases
 ## Repository structure
 
-This repository will build different docker images for different services. For that reason some folder structure is bound to the name of the service.
-
 ```
 .
-├── cmd
-│   ├── vshn-postgres-func
-│   └── vshn-redis-func
-├── kind
+├── docs
 ├── functions
 │   ├── vshn-common-func
 │   ├── vshn-postgres-func
 │   └── vshn-redis-func
+├── kind
 ├── runtime
 └── test
 ```
 
-- `./cmd` contains the entry point boilerplate for each service.
-- `./functions` contains the actual logic for the function. Each transform should be in its own package.
+- `./docs` contains relevant documentation in regard to this repository
+- `./functions` contains the actual logic for each function-io. Each function-io can have multiple transformation go functions 
 - `./runtime` contains a library with helper methods which helps with adding new functions. 
+- `./kind` contains relevant files for local dev cluster
+- `./test` contains test files
 
 Check out the docs to understand how functions from this repository work.
 
-## Add a new function
+## Add a new function-io
 
 The framework is designed to easily add new composition functions to any AppCat service.
+A function-io corresponds to one and only one composition thus multiple transformation go functions 
+can be added to a function-io.
+For instance, in `vshn-postgres-func` there are multiple transformation go functions such as `url` or `alerting`.
+
 
 To add a new function to PostgreSQL by VSHN:
 
-- Create a new package under `./functions/vshn-postgres-func`
-- Add the transform function to the list in `./cmd/vshn-postgres-func`
-- implement the actual `Transform()` function by using the helper functions from `runtime/runtime.go`
+- Create a new package under `./functions/`.
+- Create a go file and add a new transform go function to the list in `./cmd/<your-new-function-io>`.
+- Implement the actual `Transform()` go function by using the helper functions from `runtime/desired.go` and `runtime/observed.go`.
+- Register the transform go function in the `main.go`.
+- Create a new app.go under `./cmd/<your-new-function-io>` and define a new `AppInfo` object.
 
 This architecture allows us to run all the functions with a single command. But for debugging and development purpose it's possible to run each function separately, by using the `--function` flag.
 

--- a/docs/antora-preview.mk
+++ b/docs/antora-preview.mk
@@ -1,6 +1,6 @@
 
-antora_preview_version ?= 3.0.1.1
-antora_preview_cmd ?= $(DOCKER_CMD) run --rm --publish 2020:2020 --volume "${PWD}":/preview/antora docker.io/vshn/antora-preview:$(antora_preview_version) --style=vshn
+antora_preview_version ?= 3.1.2.3
+antora_preview_cmd ?= $(DOCKER_CMD) run --rm --publish 2020:2020 --volume "${PWD}":/preview/antora ghcr.io/vshn/antora-preview:$(antora_preview_version) --style=vshn
 
 .PHONY: docs-preview
 docs-preview: ## Preview the documentation

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: appcat-comp-functions
-title: Go Bootstrap
+title: AppCat Composition Functions
 version: master
 start_page: ROOT:index.adoc
 nav:

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,9 +1,8 @@
-// TODO: Edit navigation
 * xref:index.adoc[Introduction]
 * https://github.com/vshn/go-bootstrap/releases[Changelog,window=_blank] 🔗
 
 .Tutorials
-//* xref:tutorials/example.adoc[Example Tutorial]
+// * xref:explanations/runtime.adoc[Runtime Library]
 
 .How To
 //* xref:how-tos/example.adoc[Example How-To]
@@ -12,4 +11,5 @@
 //* xref:references/example.adoc[Example Reference]
 
 .Explanation
+* xref:explanations/runtime.adoc[Runtime Library]
 * xref:explanations/vshn-postgres.adoc[VSHN Postgres Functions]

--- a/docs/modules/ROOT/pages/explanations/runtime.adoc
+++ b/docs/modules/ROOT/pages/explanations/runtime.adoc
@@ -1,0 +1,26 @@
+= Runtime Library
+
+The runtime library helps to facilitate the implementation of transformation go functions.
+It allows to operate on underlying function-io resources and composites. There are 2 objects accessible
+from a runtime object:
+
+- `Observed` - the observed state of the XR and any existing composed resources.
+- `Desired` - the desired state of the XR and any composed resources.
+
+For more information on how function-io operates check the https://docs.crossplane.io/knowledge-base/guides/composition-functions/#functionio[documentation]
+from Crossplane.
+
+== Desired Object
+
+The runtime desired object has methods to obtain and update desired resources from function-io.
+
+== Observed Object
+
+The runtime observed object has methods to obtain observed resources from function-io.
+
+== Result Object
+
+Any transformation go function expects a `runtime.Result` object. This object type wraps the Crossplane
+own Result type. The runtime library has simple functions that allows creation of `runtime.Result` objects
+in various states - `fatal`, `warning` or `normal`. To understand the difference between these states
+consult crossplane https://docs.crossplane.io/knowledge-base/guides/composition-functions/#functionio[documentation].

--- a/docs/modules/ROOT/pages/explanations/vshn-postgres.adoc
+++ b/docs/modules/ROOT/pages/explanations/vshn-postgres.adoc
@@ -1,8 +1,8 @@
-= VSHN Postgres Functions
+= VSHN Postgres Function-io
 
-The set of functions applied to a VSHN Postgres composition.
+The set of transformation go functions applied to a VSHN Postgres composition.
 
-== Function URL-CONNECTION-DETAILS
+== Transformation URL-CONNECTION-DETAILS
 
 The function URL-CONNECTION-DETAILS adds a new `POSTGRES_URL` entry in  the connection detail of the composite. The value is defined as `postgres://user:password@host:port/db`. Once it is executed the client has access to the URL of its database via connection secret.
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,11 +1,9 @@
-// TODO: Edit start page
-
 = {page-component-name}
 
 [discrete]
 == Introduction
 
-Go Bootstrap is a template repository that helps bootstrapping new Go applications quickly with a standardized setup.
+appcat-comp-functions is a repository which aggregates crossplane functions for AppCat services.
 
 [discrete]
 == Documentation

--- a/functions/vshn-postgres-func/alerting.go
+++ b/functions/vshn-postgres-func/alerting.go
@@ -101,7 +101,7 @@ func deployAlertmanagerFromRef(comp *vshnv1.VSHNPostgreSQL, iof *runtime.Runtime
 		},
 	}
 
-	err = iof.PutManagedRessource(xkobj)
+	err = iof.Desired.PutManagedResource(xkobj)
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func deployAlertmanagerFromTemplate(comp *vshnv1.VSHNPostgreSQL, iof *runtime.Ru
 		return err
 	}
 
-	return iof.PutManagedRessource(xkobj)
+	return iof.Desired.PutManagedResource(xkobj)
 }
 
 func deploySecretRef(comp *vshnv1.VSHNPostgreSQL, iof *runtime.Runtime) error {
@@ -153,5 +153,5 @@ func deploySecretRef(comp *vshnv1.VSHNPostgreSQL, iof *runtime.Runtime) error {
 		},
 	}
 
-	return iof.PutManagedRessource(xkobj)
+	return iof.Desired.PutManagedResource(xkobj)
 }

--- a/functions/vshn-postgres-func/alerting.go
+++ b/functions/vshn-postgres-func/alerting.go
@@ -19,13 +19,13 @@ func AddUserAlerting(_ context.Context, log logr.Logger, iof *runtime.Runtime[vs
 
 	log.Info("Check if alerting references are set")
 
-	log.V(1).Info("Tranfsorming", "obj", iof)
+	log.V(1).Info("Transforming", "obj", iof)
 
 	err := runtime.AddToScheme(alertmanagerv1alpha1.SchemeBuilder)
 	if err != nil {
 		return err
 	}
-	comp := iof.Desired.Composite
+	comp := &iof.Desired.Composite
 
 	monitoringSpec := comp.Spec.Parameters.Monitoring
 
@@ -39,7 +39,7 @@ func AddUserAlerting(_ context.Context, log logr.Logger, iof *runtime.Runtime[vs
 		refName := comp.Spec.Parameters.Monitoring.AlertmanagerConfigRef
 		log.Info("Found an AlertmanagerConfigRef, deploying...", "refName", refName)
 
-		err := deployAlertmanagerFromRef(iof.Desired.Composite, iof)
+		err = deployAlertmanagerFromRef(&iof.Desired.Composite, iof)
 		if err != nil {
 			return err
 		}
@@ -55,7 +55,7 @@ func AddUserAlerting(_ context.Context, log logr.Logger, iof *runtime.Runtime[vs
 
 		log.Info("Found an AlertmanagerConfigTemplate, deploying...")
 
-		err := deployAlertmanagerFromTemplate(comp, iof)
+		err = deployAlertmanagerFromTemplate(comp, iof)
 		if err != nil {
 			return err
 		}
@@ -65,7 +65,7 @@ func AddUserAlerting(_ context.Context, log logr.Logger, iof *runtime.Runtime[vs
 		refName := comp.Spec.Parameters.Monitoring.AlertmanagerConfigSecretRef
 		log.Info("Found an AlertmanagerConfigSecretRef, deploying...", "refName", refName)
 
-		err := deploySecretRef(comp, iof)
+		err = deploySecretRef(comp, iof)
 		if err != nil {
 			return err
 		}

--- a/functions/vshn-postgres-func/alerting.go
+++ b/functions/vshn-postgres-func/alerting.go
@@ -100,7 +100,7 @@ func deployAlertmanagerFromRef(ctx context.Context, comp *vshnv1.VSHNPostgreSQL,
 		ToFieldPath: pointer.String("spec"),
 	}
 
-	return iof.Desired.PutIntoKubeObject(ctx, ac, comp.Name+"-alertmanagerconfig", xRef)
+	return iof.Desired.PutIntoObject(ctx, ac, comp.Name+"-alertmanagerconfig", xRef)
 }
 
 func deployAlertmanagerFromTemplate(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, iof *runtime.Runtime) error {
@@ -112,7 +112,7 @@ func deployAlertmanagerFromTemplate(ctx context.Context, comp *vshnv1.VSHNPostgr
 		Spec: *comp.Spec.Parameters.Monitoring.AlertmanagerConfigSpecTemplate,
 	}
 
-	return iof.Desired.PutIntoKubeObject(ctx, ac, comp.Name+"-alertmanagerconfig")
+	return iof.Desired.PutIntoObject(ctx, ac, comp.Name+"-alertmanagerconfig")
 }
 
 func deploySecretRef(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, iof *runtime.Runtime) error {
@@ -135,5 +135,5 @@ func deploySecretRef(ctx context.Context, comp *vshnv1.VSHNPostgreSQL, iof *runt
 		ToFieldPath: pointer.String("data"),
 	}
 
-	return iof.Desired.PutIntoKubeObject(ctx, s, comp.Name+"-alertmanagerconfigsecret", xRef)
+	return iof.Desired.PutIntoObject(ctx, s, comp.Name+"-alertmanagerconfigsecret", xRef)
 }

--- a/functions/vshn-postgres-func/alerting_test.go
+++ b/functions/vshn-postgres-func/alerting_test.go
@@ -2,7 +2,6 @@ package vshnpostgres
 
 import (
 	"context"
-	"fmt"
 	xkube "github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha1"
 	xfnv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
 	alertmanagerv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -33,7 +32,7 @@ func TestAddUserAlerting(t *testing.T) {
 			},
 			expResult: xfnv1alpha1.Result{
 				Severity: xfnv1alpha1.SeverityNormal,
-				Message:  fmt.Sprintf("function ran successfully"),
+				Message:  "function ran successfully",
 			},
 		},
 		{

--- a/functions/vshn-postgres-func/alerting_test.go
+++ b/functions/vshn-postgres-func/alerting_test.go
@@ -2,14 +2,16 @@ package vshnpostgres
 
 import (
 	"context"
+	"fmt"
+	xkube "github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha1"
+	xfnv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
+	alertmanagerv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/vshn/appcat-comp-functions/runtime"
+	v1 "k8s.io/api/core/v1"
 	"testing"
 
-	xkube "github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha1"
 	"github.com/go-logr/logr"
-	alertmanagerv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/stretchr/testify/assert"
-	vshnv1 "github.com/vshn/component-appcat/apis/vshn/v1"
-	v1 "k8s.io/api/core/v1"
 )
 
 func TestAddUserAlerting(t *testing.T) {
@@ -18,9 +20,9 @@ func TestAddUserAlerting(t *testing.T) {
 		inputFuncIO    string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
+		name      string
+		args      args
+		expResult xfnv1alpha1.Result
 	}{
 		{
 			name: "GivenNoMonitoringParams_ThenExpectNoOutput",
@@ -28,11 +30,14 @@ func TestAddUserAlerting(t *testing.T) {
 				expectedFuncIO: "alerting/01-ThenExpectNoOutput.yaml",
 				inputFuncIO:    "alerting/01-GivenNoMonitoringParams.yaml",
 			},
-			wantErr: false,
+			expResult: xfnv1alpha1.Result{
+				Severity: xfnv1alpha1.SeverityNormal,
+				Message:  fmt.Sprintf("function ran successfully"),
+			},
 		},
 		{
-			name:    "GivenConfigRefNoSecretRef_ThenExpectError",
-			wantErr: true,
+			name:      "GivenConfigRefNoSecretRef_ThenExpectError",
+			expResult: runtime.NewFatal("found AlertmanagerConfigRef but no AlertmanagerConfigSecretRef, please specify as well").Resolve(),
 			args: args{
 				expectedFuncIO: "alerting/02-ThenExpectError.yaml",
 				inputFuncIO:    "alerting/02-GivenConfigRefNoSecretRef.yaml",
@@ -44,20 +49,13 @@ func TestAddUserAlerting(t *testing.T) {
 			ctx := context.Background()
 			log := logr.FromContextOrDiscard(ctx)
 
-			iof := getFunctionFromFile(t, tt.args.inputFuncIO)
-			comp := &vshnv1.VSHNPostgreSQL{}
-			inComp := getCompositeFromIO(t, iof, comp)
-			expIof := getFunctionFromFile(t, tt.args.expectedFuncIO)
+			iof := loadRuntimeFromFile(t, tt.args.inputFuncIO)
+			expIof := loadRuntimeFromFile(t, tt.args.expectedFuncIO)
 
-			_, err := AddUserAlerting(ctx, log, iof, inComp)
+			r := AddUserAlerting(log, iof)
 
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, expIof, iof)
-			}
-
+			assert.Equal(t, tt.expResult, r.Resolve())
+			assert.Equal(t, getFunctionIo(expIof), getFunctionIo(iof))
 		})
 	}
 }
@@ -69,31 +67,28 @@ func TestGivenConfigRefAndSecretThenExpectOutput(t *testing.T) {
 
 	t.Run("GivenConfigRefAndSecret_ThenExpectOutput", func(t *testing.T) {
 
-		iof := getFunctionFromFile(t, "alerting/03-GivenConfigRefAndSecret.yaml")
-		comp := &vshnv1.VSHNPostgreSQL{}
-		inComp := getCompositeFromIO(t, iof, comp)
+		iof := loadRuntimeFromFile(t, "alerting/03-GivenConfigRefAndSecret.yaml")
 
-		_, err := AddUserAlerting(ctx, log, iof, inComp)
-		assert.NoError(t, err)
+		r := AddUserAlerting(log, iof)
+		assert.Equal(t, runtime.NewNormal(), r)
 
 		resName := "psql-alertmanagerconfig"
 		kubeObject := &xkube.Object{}
 		assert.NoError(t, iof.Desired.GetManagedResource(resName, kubeObject))
 
-		assert.Equal(t, comp.Labels["crossplane.io/claim-namespace"], kubeObject.Spec.References[0].PatchesFrom.Namespace)
-		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigRef, kubeObject.Spec.References[0].PatchesFrom.Name)
+		assert.Equal(t, iof.Desired.Composite.Labels["crossplane.io/claim-namespace"], kubeObject.Spec.References[0].PatchesFrom.Namespace)
+		assert.Equal(t, iof.Desired.Composite.Spec.Parameters.Monitoring.AlertmanagerConfigRef, kubeObject.Spec.References[0].PatchesFrom.Name)
 
 		alertConfig := &alertmanagerv1alpha1.AlertmanagerConfig{}
-		assert.NoError(t, iof.Desired.GetFromKubeObject(ctx, alertConfig, resName))
-		assert.Equal(t, comp.Status.InstanceNamespace, alertConfig.GetNamespace())
+		assert.NoError(t, iof.Desired.GetFromKubeObject(alertConfig, resName))
+		assert.Equal(t, iof.Desired.Composite.Status.InstanceNamespace, alertConfig.GetNamespace())
 
 		secretName := "psql-alertmanagerconfigsecret"
 		secret := &v1.Secret{}
-		assert.NoError(t, iof.GetFromDesiredKubeObject(ctx, secret, secretName))
+		assert.NoError(t, iof.Desired.GetFromKubeObject(secret, secretName))
 
-		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigSecretRef, secret.GetName())
+		assert.Equal(t, iof.Desired.Composite.Spec.Parameters.Monitoring.AlertmanagerConfigSecretRef, secret.GetName())
 	})
-
 }
 
 func TestGivenConfigTemplateAndSecretThenExpectOutput(t *testing.T) {
@@ -102,12 +97,10 @@ func TestGivenConfigTemplateAndSecretThenExpectOutput(t *testing.T) {
 
 	t.Run("GivenConfigTemplateAndSecret_ThenExpectOutput", func(t *testing.T) {
 
-		iof := getFunctionFromFile(t, "alerting/04-GivenConfigTemplateAndSecret.yaml")
-		comp := &vshnv1.VSHNPostgreSQL{}
-		inComp := getCompositeFromIO(t, iof, comp)
+		iof := loadRuntimeFromFile(t, "alerting/04-GivenConfigTemplateAndSecret.yaml")
 
-		_, err := AddUserAlerting(ctx, log, iof, inComp)
-		assert.NoError(t, err)
+		r := AddUserAlerting(log, iof)
+		assert.Equal(t, runtime.NewNormal(), r)
 
 		resName := "psql-alertmanagerconfig"
 		kubeObject := &xkube.Object{}
@@ -116,14 +109,14 @@ func TestGivenConfigTemplateAndSecretThenExpectOutput(t *testing.T) {
 		assert.Empty(t, kubeObject.Spec.References)
 
 		alertConfig := &alertmanagerv1alpha1.AlertmanagerConfig{}
-		assert.NoError(t, iof.Desired.GetFromKubeObject(ctx, alertConfig, resName))
-		assert.Equal(t, comp.Status.InstanceNamespace, alertConfig.GetNamespace())
-		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigSpecTemplate, &alertConfig.Spec)
+		assert.NoError(t, iof.Desired.GetFromKubeObject(alertConfig, resName))
+		assert.Equal(t, iof.Desired.Composite.Status.InstanceNamespace, alertConfig.GetNamespace())
+		assert.Equal(t, iof.Desired.Composite.Spec.Parameters.Monitoring.AlertmanagerConfigSpecTemplate, &alertConfig.Spec)
 
 		secretName := "psql-alertmanagerconfigsecret"
 		secret := &v1.Secret{}
-		assert.NoError(t, iof.GetFromDesiredKubeObject(ctx, secret, secretName))
+		assert.NoError(t, iof.Desired.GetFromKubeObject(secret, secretName))
 
-		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigSecretRef, secret.GetName())
+		assert.Equal(t, iof.Desired.Composite.Spec.Parameters.Monitoring.AlertmanagerConfigSecretRef, secret.GetName())
 	})
 }

--- a/functions/vshn-postgres-func/alerting_test.go
+++ b/functions/vshn-postgres-func/alerting_test.go
@@ -71,7 +71,7 @@ func TestGivenConfigRefAndSecretThenExpectOutput(t *testing.T) {
 
 		resName := "psql-alertmanagerconfig"
 		kubeObject := &xkube.Object{}
-		assert.NoError(t, iof.Desired.GetManagedResource(resName, kubeObject))
+		assert.NoError(t, iof.Desired.GetManagedResource(ctx, resName, kubeObject))
 
 		assert.Equal(t, iof.Desired.Composite.Labels["crossplane.io/claim-namespace"], kubeObject.Spec.References[0].PatchesFrom.Namespace)
 		assert.Equal(t, iof.Desired.Composite.Spec.Parameters.Monitoring.AlertmanagerConfigRef, kubeObject.Spec.References[0].PatchesFrom.Name)
@@ -100,7 +100,7 @@ func TestGivenConfigTemplateAndSecretThenExpectOutput(t *testing.T) {
 
 		resName := "psql-alertmanagerconfig"
 		kubeObject := &xkube.Object{}
-		assert.NoError(t, iof.Desired.GetManagedResource(resName, kubeObject))
+		assert.NoError(t, iof.Desired.GetManagedResource(ctx, resName, kubeObject))
 
 		assert.Empty(t, kubeObject.Spec.References)
 

--- a/functions/vshn-postgres-func/alerting_test.go
+++ b/functions/vshn-postgres-func/alerting_test.go
@@ -72,7 +72,7 @@ func TestGivenConfigRefAndSecretThenExpectOutput(t *testing.T) {
 
 		resName := "psql-alertmanagerconfig"
 		kubeObject := &xkube.Object{}
-		assert.NoError(t, iof.Desired.GetManagedResource(ctx, resName, kubeObject))
+		assert.NoError(t, iof.Desired.GetManagedResource(ctx, kubeObject, resName))
 
 		comp := &vshnv1.VSHNPostgreSQL{}
 		assert.NoError(t, iof.Observed.GetComposite(ctx, comp))
@@ -103,7 +103,7 @@ func TestGivenConfigTemplateAndSecretThenExpectOutput(t *testing.T) {
 
 		resName := "psql-alertmanagerconfig"
 		kubeObject := &xkube.Object{}
-		assert.NoError(t, iof.Desired.GetManagedResource(ctx, resName, kubeObject))
+		assert.NoError(t, iof.Desired.GetManagedResource(ctx, kubeObject, resName))
 
 		assert.Empty(t, kubeObject.Spec.References)
 

--- a/functions/vshn-postgres-func/alerting_test.go
+++ b/functions/vshn-postgres-func/alerting_test.go
@@ -72,7 +72,7 @@ func TestGivenConfigRefAndSecretThenExpectOutput(t *testing.T) {
 
 		resName := "psql-alertmanagerconfig"
 		kubeObject := &xkube.Object{}
-		assert.NoError(t, iof.Desired.GetManagedResource(ctx, kubeObject, resName))
+		assert.NoError(t, iof.Desired.Get(ctx, kubeObject, resName))
 
 		comp := &vshnv1.VSHNPostgreSQL{}
 		assert.NoError(t, iof.Observed.GetComposite(ctx, comp))
@@ -80,12 +80,12 @@ func TestGivenConfigRefAndSecretThenExpectOutput(t *testing.T) {
 		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigRef, kubeObject.Spec.References[0].PatchesFrom.Name)
 
 		alertConfig := &alertmanagerv1alpha1.AlertmanagerConfig{}
-		assert.NoError(t, iof.Desired.GetFromKubeObject(ctx, alertConfig, resName))
+		assert.NoError(t, iof.Desired.GetFromObject(ctx, alertConfig, resName))
 		assert.Equal(t, comp.Status.InstanceNamespace, alertConfig.GetNamespace())
 
 		secretName := "psql-alertmanagerconfigsecret"
 		secret := &v1.Secret{}
-		assert.NoError(t, iof.Desired.GetFromKubeObject(ctx, secret, secretName))
+		assert.NoError(t, iof.Desired.GetFromObject(ctx, secret, secretName))
 
 		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigSecretRef, secret.GetName())
 	})
@@ -103,20 +103,20 @@ func TestGivenConfigTemplateAndSecretThenExpectOutput(t *testing.T) {
 
 		resName := "psql-alertmanagerconfig"
 		kubeObject := &xkube.Object{}
-		assert.NoError(t, iof.Desired.GetManagedResource(ctx, kubeObject, resName))
+		assert.NoError(t, iof.Desired.Get(ctx, kubeObject, resName))
 
 		assert.Empty(t, kubeObject.Spec.References)
 
 		alertConfig := &alertmanagerv1alpha1.AlertmanagerConfig{}
 		comp := &vshnv1.VSHNPostgreSQL{}
-		assert.NoError(t, iof.Desired.GetFromKubeObject(ctx, alertConfig, resName))
+		assert.NoError(t, iof.Desired.GetFromObject(ctx, alertConfig, resName))
 		assert.NoError(t, iof.Observed.GetComposite(ctx, comp))
 		assert.Equal(t, comp.Status.InstanceNamespace, alertConfig.GetNamespace())
 		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigSpecTemplate, &alertConfig.Spec)
 
 		secretName := "psql-alertmanagerconfigsecret"
 		secret := &v1.Secret{}
-		assert.NoError(t, iof.Desired.GetFromKubeObject(ctx, secret, secretName))
+		assert.NoError(t, iof.Desired.GetFromObject(ctx, secret, secretName))
 
 		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigSecretRef, secret.GetName())
 	})

--- a/functions/vshn-postgres-func/alerting_test.go
+++ b/functions/vshn-postgres-func/alerting_test.go
@@ -78,13 +78,13 @@ func TestGivenConfigRefAndSecretThenExpectOutput(t *testing.T) {
 
 		resName := "psql-alertmanagerconfig"
 		kubeObject := &xkube.Object{}
-		assert.NoError(t, iof.GetManagedRessourceFromDesired(resName, kubeObject))
+		assert.NoError(t, iof.Desired.GetManagedResource(resName, kubeObject))
 
 		assert.Equal(t, comp.Labels["crossplane.io/claim-namespace"], kubeObject.Spec.References[0].PatchesFrom.Namespace)
 		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigRef, kubeObject.Spec.References[0].PatchesFrom.Name)
 
 		alertConfig := &alertmanagerv1alpha1.AlertmanagerConfig{}
-		assert.NoError(t, iof.GetFromDesiredKubeObject(ctx, alertConfig, resName))
+		assert.NoError(t, iof.Desired.GetFromKubeObject(ctx, alertConfig, resName))
 		assert.Equal(t, comp.Status.InstanceNamespace, alertConfig.GetNamespace())
 
 		secretName := "psql-alertmanagerconfigsecret"
@@ -111,12 +111,12 @@ func TestGivenConfigTemplateAndSecretThenExpectOutput(t *testing.T) {
 
 		resName := "psql-alertmanagerconfig"
 		kubeObject := &xkube.Object{}
-		assert.NoError(t, iof.GetManagedRessourceFromDesired(resName, kubeObject))
+		assert.NoError(t, iof.Desired.GetManagedResource(resName, kubeObject))
 
 		assert.Empty(t, kubeObject.Spec.References)
 
 		alertConfig := &alertmanagerv1alpha1.AlertmanagerConfig{}
-		assert.NoError(t, iof.GetFromDesiredKubeObject(ctx, alertConfig, resName))
+		assert.NoError(t, iof.Desired.GetFromKubeObject(ctx, alertConfig, resName))
 		assert.Equal(t, comp.Status.InstanceNamespace, alertConfig.GetNamespace())
 		assert.Equal(t, comp.Spec.Parameters.Monitoring.AlertmanagerConfigSpecTemplate, &alertConfig.Spec)
 

--- a/functions/vshn-postgres-func/app.go
+++ b/functions/vshn-postgres-func/app.go
@@ -10,5 +10,5 @@ var AI = runtime.AppInfo{
 	Commit:      "-dirty-",
 	Date:        time.Now().Format("2006-01-02"),
 	AppName:     "functionio-vshn-postgresql-url",
-	AppLongName: "A crossplane composition function to craft an URL from an instance of a vshn postgres database",
+	AppLongName: "A crossplane composition function to craft an URL from an instance of a VSHN postgres database",
 }

--- a/functions/vshn-postgres-func/common_test.go
+++ b/functions/vshn-postgres-func/common_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	xfnv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
 	"github.com/vshn/appcat-comp-functions/runtime"
-	v1 "github.com/vshn/component-appcat/apis/vshn/v1"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -14,19 +13,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func loadRuntimeFromFile(t assert.TestingT, file string) *runtime.Runtime[v1.VSHNPostgreSQL, *v1.VSHNPostgreSQL] {
+func loadRuntimeFromFile(t assert.TestingT, file string) *runtime.Runtime {
 	p, _ := filepath.Abs(".")
 	before, _, _ := strings.Cut(p, "/functions")
 	f, err := os.Open(before + "/test/transforms/vshn-postgres/" + file)
 	assert.NoError(t, err)
 	os.Stdin = f
-	funcIO, err := runtime.NewRuntime[v1.VSHNPostgreSQL, *v1.VSHNPostgreSQL](context.Background())
+	funcIO, err := runtime.NewRuntime(context.Background())
 	assert.NoError(t, err)
 
 	return funcIO
 }
 
-func getFunctionIo(funcIO *runtime.Runtime[v1.VSHNPostgreSQL, *v1.VSHNPostgreSQL]) xfnv1alpha1.FunctionIO {
+func getFunctionIo(funcIO *runtime.Runtime) xfnv1alpha1.FunctionIO {
 	field := reflect.ValueOf(funcIO).Elem().FieldByName("io")
 	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface().(xfnv1alpha1.FunctionIO)
 }

--- a/functions/vshn-postgres-func/common_test.go
+++ b/functions/vshn-postgres-func/common_test.go
@@ -25,7 +25,7 @@ func getFunctionFromFile(t assert.TestingT, file string) *runtime.Runtime {
 }
 
 func getCompositeFromIO[T any](t assert.TestingT, io *runtime.Runtime, obj *T) *T {
-	err := json.Unmarshal(io.Observed.Composite.Resource.Raw, obj)
+	err := json.Unmarshal(io.Func.Observed.Composite.Resource.Raw, obj)
 	assert.NoError(t, err)
 
 	return obj

--- a/functions/vshn-postgres-func/common_test.go
+++ b/functions/vshn-postgres-func/common_test.go
@@ -30,10 +30,3 @@ func getFunctionIo(funcIO *runtime.Runtime[v1.VSHNPostgreSQL, *v1.VSHNPostgreSQL
 	field := reflect.ValueOf(funcIO).Elem().FieldByName("io")
 	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface().(xfnv1alpha1.FunctionIO)
 }
-
-func setFunctionIO(funcIO *runtime.Runtime[v1.VSHNPostgreSQL, *v1.VSHNPostgreSQL], value xfnv1alpha1.FunctionIO) {
-	field := reflect.ValueOf(funcIO).Elem().FieldByName("io")
-	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).
-		Elem().
-		Set(reflect.ValueOf(value))
-}

--- a/functions/vshn-postgres-func/url.go
+++ b/functions/vshn-postgres-func/url.go
@@ -44,7 +44,7 @@ func Transform(ctx context.Context, log logr.Logger, iof *runtime.Runtime, comp 
 	log.Info("Getting connection secret from managed kubernetes object")
 	s := &v1.Secret{}
 
-	err := iof.GetFromObservedKubeObject(ctx, s, connectionSecretResourceName)
+	err := iof.Observed.GetFromKubeObject(ctx, s, connectionSecretResourceName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get connection secret object: %w", err)
 	}
@@ -52,8 +52,8 @@ func Transform(ctx context.Context, log logr.Logger, iof *runtime.Runtime, comp 
 	log.Info("Setting POSTRESQL_URL env variable into connection secret")
 	val := getPostgresURL(ctx, s)
 
-	iof.Desired.Composite.ConnectionDetails =
-		append(iof.Desired.Composite.ConnectionDetails, v1alpha1.ExplicitConnectionDetail{
+	iof.Func.Desired.Composite.ConnectionDetails =
+		append(iof.Func.Desired.Composite.ConnectionDetails, v1alpha1.ExplicitConnectionDetail{
 			Name:  PostgresqlUrl,
 			Value: val,
 		})

--- a/functions/vshn-postgres-func/url.go
+++ b/functions/vshn-postgres-func/url.go
@@ -58,7 +58,7 @@ func AddUrlToConnectionDetails(ctx context.Context, iof *runtime.Runtime) runtim
 	if val == "" {
 		return runtime.NewWarning(ctx, "User, pass, host, port or db value is missing from connection secret, skipping transformation")
 	}
-	iof.Desired.AddToCompositeConnectionDetails(ctx, v1alpha1.ExplicitConnectionDetail{
+	iof.Desired.PutCompositeConnectionDetail(ctx, v1alpha1.ExplicitConnectionDetail{
 		Name:  PostgresqlUrl,
 		Value: val,
 	})

--- a/functions/vshn-postgres-func/url.go
+++ b/functions/vshn-postgres-func/url.go
@@ -48,7 +48,7 @@ func AddUrlToConnectionDetails(ctx context.Context, iof *runtime.Runtime) runtim
 	log.Info("Getting connection secret from managed kubernetes object")
 	s := &v1.Secret{}
 
-	err = iof.Observed.GetFromKubeObject(ctx, s, connectionSecretResourceName)
+	err = iof.Observed.GetFromObject(ctx, s, connectionSecretResourceName)
 	if err != nil {
 		return runtime.NewFatalErr(ctx, "Cannot get connection secret object", err)
 	}

--- a/functions/vshn-postgres-func/url_test.go
+++ b/functions/vshn-postgres-func/url_test.go
@@ -44,7 +44,7 @@ func TestTransform(t *testing.T) {
 
 		// Then
 		assert.Equal(t, expectResult, result)
-		assert.Equal(t, expectURL, r.Desired.ConnectionDetails[0].Value)
+		assert.Equal(t, expectURL, r.Desired.GetCompositeConnectionDetails(ctx)[0].Value)
 	})
 }
 

--- a/functions/vshn-postgres-func/url_test.go
+++ b/functions/vshn-postgres-func/url_test.go
@@ -5,25 +5,22 @@ import (
 	"github.com/vshn/appcat-comp-functions/runtime"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 )
 
 func TestTransform_NoInstanceNamespace(t *testing.T) {
+	ctx := context.Background()
 	expectIo := loadRuntimeFromFile(t, "url/01_expected_no-instance-namespace.yaml")
-	expectResult := runtime.NewWarning("Composite is missing instance namespace, skipping transformation")
+	expectResult := runtime.NewWarning(ctx, "Composite is missing instance namespace, skipping transformation")
 
 	t.Run("WhenNoInstance_ThenNoErrorAndNoChanges", func(t *testing.T) {
 
 		//Given
 		io := loadRuntimeFromFile(t, "url/01_input_no-instance-namespace.yaml")
-		//comp := getCompositeFromIO(t, io, vpu)
-		ctx := context.Background()
-		log := logr.FromContextOrDiscard(ctx)
 
 		// When
-		result := AddUrlToConnectionDetails(log, io)
+		result := AddUrlToConnectionDetails(ctx, io)
 
 		// Then
 		assert.Equal(t, expectResult, result)
@@ -32,6 +29,7 @@ func TestTransform_NoInstanceNamespace(t *testing.T) {
 }
 
 func TestTransform(t *testing.T) {
+	ctx := context.Background()
 	expectURL := "postgres://postgres:639b-9076-4de6-a35@" +
 		"pgsql-gc9x4.vshn-postgresql-pgsql-gc9x4.svc.cluster.local:5432/postgres"
 	expectResult := runtime.NewNormal()
@@ -40,11 +38,9 @@ func TestTransform(t *testing.T) {
 
 		//Given
 		r := loadRuntimeFromFile(t, "url/02_input_function-io.yaml")
-		ctx := context.Background()
-		log := logr.FromContextOrDiscard(ctx)
 
 		// When
-		result := AddUrlToConnectionDetails(log, r)
+		result := AddUrlToConnectionDetails(ctx, r)
 
 		// Then
 		assert.Equal(t, expectResult, result)

--- a/functions/vshn-postgres-func/url_test.go
+++ b/functions/vshn-postgres-func/url_test.go
@@ -52,7 +52,7 @@ func TestTransform(t *testing.T) {
 
 		// Then
 		assert.NoError(t, err)
-		assert.Equal(t, expectURL, io.Desired.Composite.ConnectionDetails[0].Value)
+		assert.Equal(t, expectURL, io.Func.Desired.Composite.ConnectionDetails[0].Value)
 		assert.Equal(t, comp, actualComp)
 	})
 }

--- a/functions/vshn-postgres-func/url_test.go
+++ b/functions/vshn-postgres-func/url_test.go
@@ -25,7 +25,7 @@ func TestTransform_NoInstanceNamespace(t *testing.T) {
 		log := logr.FromContextOrDiscard(ctx)
 
 		// When
-		comp, err := Transform(ctx, log, io, comp)
+		comp, err := AddUrlToConnectionDetails(ctx, log, io, comp)
 
 		// Then
 		assert.NoError(t, err)
@@ -48,11 +48,11 @@ func TestTransform(t *testing.T) {
 		log := logr.FromContextOrDiscard(ctx)
 
 		// When
-		actualComp, err := Transform(ctx, log, io, comp)
+		actualComp, err := AddUrlToConnectionDetails(ctx, log, io)
 
 		// Then
 		assert.NoError(t, err)
-		assert.Equal(t, expectURL, io.Func.Desired.Composite.ConnectionDetails[0].Value)
+		assert.Equal(t, expectURL, io.GetCompositeD().ConnectionDetails[0].Value)
 		assert.Equal(t, comp, actualComp)
 	})
 }

--- a/functions/vshn-postgres-func/url_test.go
+++ b/functions/vshn-postgres-func/url_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 func TestTransform_NoInstanceNamespace(t *testing.T) {
-	expectIo := getFunctionFromFile(t, "url/01_expected_no-instance-namespace.yaml")
+	expectIo := loadRuntimeFromFile(t, "url/01_expected_no-instance-namespace.yaml")
 	expectResult := runtime.NewWarning("Composite is missing instance namespace, skipping transformation")
 
 	t.Run("WhenNoInstance_ThenNoErrorAndNoChanges", func(t *testing.T) {
 
 		//Given
-		io := getFunctionFromFile(t, "url/01_input_no-instance-namespace.yaml")
+		io := loadRuntimeFromFile(t, "url/01_input_no-instance-namespace.yaml")
 		//comp := getCompositeFromIO(t, io, vpu)
 		ctx := context.Background()
 		log := logr.FromContextOrDiscard(ctx)
@@ -39,16 +39,16 @@ func TestTransform(t *testing.T) {
 	t.Run("WhenNormalIO_ThenAddPostgreSQLUrl", func(t *testing.T) {
 
 		//Given
-		io := getFunctionFromFile(t, "url/02_input_function-io.yaml")
+		r := loadRuntimeFromFile(t, "url/02_input_function-io.yaml")
 		ctx := context.Background()
 		log := logr.FromContextOrDiscard(ctx)
 
 		// When
-		result := AddUrlToConnectionDetails(log, io)
+		result := AddUrlToConnectionDetails(log, r)
 
 		// Then
 		assert.Equal(t, expectResult, result)
-		assert.Equal(t, expectURL, io.Desired.ConnectionDetails[0].Value)
+		assert.Equal(t, expectURL, r.Desired.ConnectionDetails[0].Value)
 	})
 }
 

--- a/functions/vshn-postgres-func/url_test.go
+++ b/functions/vshn-postgres-func/url_test.go
@@ -2,58 +2,53 @@ package vshnpostgres
 
 import (
 	"context"
+	"github.com/vshn/appcat-comp-functions/runtime"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
-	vshnv1 "github.com/vshn/component-appcat/apis/vshn/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
 func TestTransform_NoInstanceNamespace(t *testing.T) {
 	expectIo := getFunctionFromFile(t, "url/01_expected_no-instance-namespace.yaml")
-	expectVpu := &vshnv1.VSHNPostgreSQL{}
-	expectComp := getCompositeFromIO(t, expectIo, expectVpu)
+	expectResult := runtime.NewWarning("Composite is missing instance namespace, skipping transformation")
 
 	t.Run("WhenNoInstance_ThenNoErrorAndNoChanges", func(t *testing.T) {
 
 		//Given
 		io := getFunctionFromFile(t, "url/01_input_no-instance-namespace.yaml")
-		vpu := &vshnv1.VSHNPostgreSQL{}
-		comp := getCompositeFromIO(t, io, vpu)
+		//comp := getCompositeFromIO(t, io, vpu)
 		ctx := context.Background()
 		log := logr.FromContextOrDiscard(ctx)
 
 		// When
-		comp, err := AddUrlToConnectionDetails(ctx, log, io, comp)
+		result := AddUrlToConnectionDetails(log, io)
 
 		// Then
-		assert.NoError(t, err)
+		assert.Equal(t, expectResult, result)
 		assert.Equal(t, expectIo, io)
-		assert.Equal(t, expectComp, comp)
 	})
 }
 
 func TestTransform(t *testing.T) {
 	expectURL := "postgres://postgres:639b-9076-4de6-a35@" +
 		"pgsql-gc9x4.vshn-postgresql-pgsql-gc9x4.svc.cluster.local:5432/postgres"
+	expectResult := runtime.NewNormal()
 
 	t.Run("WhenNormalIO_ThenAddPostgreSQLUrl", func(t *testing.T) {
 
 		//Given
 		io := getFunctionFromFile(t, "url/02_input_function-io.yaml")
-		vpu := &vshnv1.VSHNPostgreSQL{}
-		comp := getCompositeFromIO(t, io, vpu)
 		ctx := context.Background()
 		log := logr.FromContextOrDiscard(ctx)
 
 		// When
-		actualComp, err := AddUrlToConnectionDetails(ctx, log, io)
+		result := AddUrlToConnectionDetails(log, io)
 
 		// Then
-		assert.NoError(t, err)
-		assert.Equal(t, expectURL, io.GetCompositeD().ConnectionDetails[0].Value)
-		assert.Equal(t, comp, actualComp)
+		assert.Equal(t, expectResult, result)
+		assert.Equal(t, expectURL, io.Desired.ConnectionDetails[0].Value)
 	})
 }
 
@@ -102,11 +97,8 @@ func TestGetPostgresURL(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			// Given
-			ctx := context.Background()
-
 			// When
-			url := getPostgresURL(ctx, tc.secret)
+			url := getPostgresURL(tc.secret)
 
 			// Then
 			assert.Equal(t, tc.expectUrl, url)

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 
 var postgresFunctions = []runtime.Transform[vshnv1.VSHNPostgreSQL, *vshnv1.VSHNPostgreSQL]{
 	{
-		Name:          "url-connection-detail",
-		TransformFunc: vp.Transform,
+		Name:          "url-connection-details",
+		TransformFunc: vp.AddUrlToConnectionDetails,
 	},
 	{
 		Name:          "user-alerting",

--- a/main.go
+++ b/main.go
@@ -6,11 +6,9 @@ import (
 	vp "github.com/vshn/appcat-comp-functions/functions/vshn-postgres-func"
 	"github.com/vshn/appcat-comp-functions/runtime"
 	"os"
-
-	vshnv1 "github.com/vshn/component-appcat/apis/vshn/v1"
 )
 
-var postgresFunctions = []runtime.Transform[vshnv1.VSHNPostgreSQL, *vshnv1.VSHNPostgreSQL]{
+var postgresFunctions = []runtime.Transform{
 	{
 		Name:          "url-connection-details",
 		TransformFunc: vp.AddUrlToConnectionDetails,

--- a/runtime/desired.go
+++ b/runtime/desired.go
@@ -23,7 +23,7 @@ type DesiredResources[T any, O interface {
 // GetFromKubeObject gets the k8s resource o from a provider kubernetes object kon (Kube Object Name)
 // from the desired array of the FunctionIO.
 func (d *DesiredResources[T, O]) GetFromKubeObject(ctx context.Context, o client.Object, kon string) error {
-	ko, err := getKubeObjectFrom(ctx, &d.Resources, o, kon)
+	ko, err := getKubeObjectFrom(ctx, &d.Resources, kon)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (d *DesiredResources[T, O]) PutIntoKubeObject(ctx context.Context, o client
 			References: refs,
 		},
 	}
-	err := getFrom(&d.Resources, ko, kon)
+	err := getFrom(ctx, &d.Resources, ko, kon)
 	if err != nil && err != ErrNotFound {
 		return err
 	}
@@ -89,8 +89,8 @@ func (d *DesiredResources[T, O]) PutIntoKubeObject(ctx context.Context, o client
 
 // GetManagedResource will unmarshall the resource from the desired array.
 // This will return any changes that a previous function has made to the desired array.
-func (d *DesiredResources[T, O]) GetManagedResource(resName string, obj client.Object) error {
-	return getFrom(&d.Resources, obj, resName)
+func (d *DesiredResources[T, O]) GetManagedResource(ctx context.Context, resName string, obj client.Object) error {
+	return getFrom(ctx, &d.Resources, obj, resName)
 }
 
 // PutManagedResource will add the object as is to the FunctionIO desired array.

--- a/runtime/desired.go
+++ b/runtime/desired.go
@@ -162,14 +162,14 @@ func (d *DesiredResources) ListResources() []Resource {
 }
 
 // RemoveResource removes a resource by name from the managed resources
-func (d *DesiredResources) RemoveResource(name string) []Resource {
+func (d *DesiredResources) RemoveResource(name string) bool {
 	for i, r := range d.resources {
 		if r.GetName() == name {
 			d.resources = append(d.resources[:i], d.resources[i+1:]...)
-			return d.resources
+			return true
 		}
 	}
-	return d.resources
+	return false
 }
 
 // desiredResource is a wrapper around xfnv1alpha1.DesiredResource

--- a/runtime/desired.go
+++ b/runtime/desired.go
@@ -31,7 +31,7 @@ func (d *DesiredResources[T, O]) GetFromKubeObject(ctx context.Context, o client
 }
 
 // PutIntoKubeObject adds or updates the desired resource into its kube object
-func (d *DesiredResources[T, O]) PutIntoKubeObject(ctx context.Context, o client.Object, kon string) error {
+func (d *DesiredResources[T, O]) PutIntoKubeObject(ctx context.Context, o client.Object, kon string, refs ...xkube.Reference) error {
 	log := controllerruntime.LoggerFrom(ctx)
 
 	ko := &xkube.Object{
@@ -39,9 +39,12 @@ func (d *DesiredResources[T, O]) PutIntoKubeObject(ctx context.Context, o client
 			Kind:       xkube.ObjectKind,
 			APIVersion: xkube.ObjectKindAPIVersion,
 		},
+		Spec: xkube.ObjectSpec{
+			References: refs,
+		},
 	}
 	err := getFrom(&d.Resources, ko, kon)
-	if err != nil {
+	if err != nil && err != ErrNotFound {
 		return err
 	}
 
@@ -50,6 +53,7 @@ func (d *DesiredResources[T, O]) PutIntoKubeObject(ctx context.Context, o client
 	if err != nil {
 		return err
 	}
+
 	return d.put(ko, kon)
 }
 

--- a/runtime/desired.go
+++ b/runtime/desired.go
@@ -14,7 +14,7 @@ import (
 
 type DesiredResources struct {
 	resources []Resource
-	composite *xfnv1alpha1.DesiredComposite
+	composite xfnv1alpha1.DesiredComposite
 }
 
 // GetFromKubeObject gets the k8s resource o from a provider kubernetes object kon (Kube Object Name)

--- a/runtime/desired.go
+++ b/runtime/desired.go
@@ -1,0 +1,109 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	xkube "github.com/crossplane-contrib/provider-kubernetes/apis/object/v1alpha1"
+	xfnv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DesiredResources struct {
+	resources *[]Resource
+}
+
+// GetFromKubeObject gets the k8s resource o from a provider kubernetes object kon (Kube Object Name)
+// from the desired array of the FunctionIO.
+func (d *DesiredResources) GetFromKubeObject(ctx context.Context, o client.Object, kon string) error {
+	ko, err := getKubeObjectFrom(ctx, d.resources, o, kon)
+	if err != nil {
+		return err
+	}
+	return fromKubeObject(ko, o)
+}
+
+// PutIntoKubeObject adds or updates the desired resource into its kube object
+func (d *DesiredResources) PutIntoKubeObject(ctx context.Context, o client.Object, kon string) error {
+	log := controllerruntime.LoggerFrom(ctx)
+
+	ko := &xkube.Object{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       xkube.ObjectKind,
+			APIVersion: xkube.ObjectKindAPIVersion,
+		},
+	}
+	err := getFrom(d.resources, ko, kon)
+	if err != nil {
+		return err
+	}
+
+	log.V(1).Info("Put object into kube object", "object", o, "kube object name", kon)
+	err = updateKubeObject(o, ko)
+	if err != nil {
+		return err
+	}
+	return d.put(ko, kon)
+}
+
+// GetManagedResource will unmarshall the resource from the desired array.
+// This will return any changes that a previous function has made to the desired array.
+func (d *DesiredResources) GetManagedResource(resName string, obj client.Object) error {
+	return getFrom(d.resources, obj, resName)
+}
+
+// PutManagedResource will add the object as is to the FunctionIO desired array.
+// It assumes that the given object is adheres to Crossplane's ManagedResource model.
+func (d *DesiredResources) PutManagedResource(obj client.Object) error {
+	return d.put(obj, obj.GetName())
+}
+
+func (d *DesiredResources) put(obj client.Object, resName string) error {
+	kind, _, err := s.ObjectKinds(obj)
+	if err != nil {
+		return err
+	}
+
+	obj.GetObjectKind().SetGroupVersionKind(kind[0])
+	rawData, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	for _, res := range *d.resources {
+		if res.GetName() == resName {
+			res.SetRaw(rawData)
+			return nil
+		}
+	}
+
+	*d.resources = append(*d.resources, &desiredResource{
+		xfnv1alpha1.DesiredResource{
+			Name: resName,
+			Resource: runtime.RawExtension{
+				Raw: rawData,
+			},
+		},
+	})
+	return nil
+}
+
+// desiredResource is a wrapper around xfnv1alpha1.DesiredResource
+// so we can satisfy the Resource interface.
+type desiredResource struct {
+	xfnv1alpha1.DesiredResource
+}
+
+func (d *desiredResource) GetName() string {
+	return d.Name
+}
+
+func (d *desiredResource) GetRaw() []byte {
+	return d.Resource.Raw
+}
+
+func (d *desiredResource) SetRaw(raw []byte) {
+	d.Resource.Raw = raw
+}

--- a/runtime/desired.go
+++ b/runtime/desired.go
@@ -156,6 +156,22 @@ func (d *DesiredResources) AddToCompositeConnectionDetails(_ context.Context, cd
 	d.composite.ConnectionDetails = append(d.composite.ConnectionDetails, cd)
 }
 
+// ListResources return the list of managed resources from desired object
+func (d *DesiredResources) ListResources() []Resource {
+	return d.resources
+}
+
+// RemoveResource removes a resource by name from the managed resources
+func (d *DesiredResources) RemoveResource(name string) []Resource {
+	for i, r := range d.resources {
+		if r.GetName() == name {
+			d.resources = append(d.resources[:i], d.resources[i+1:]...)
+			return d.resources
+		}
+	}
+	return d.resources
+}
+
 // desiredResource is a wrapper around xfnv1alpha1.DesiredResource
 // so we can satisfy the Resource interface.
 type desiredResource xfnv1alpha1.DesiredResource

--- a/runtime/observed.go
+++ b/runtime/observed.go
@@ -6,14 +6,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type ObservedResources struct {
-	resources *[]Resource
+type ObservedResources[T any, O interface {
+	client.Object
+	*T
+}] struct {
+	Resources         *[]Resource
+	Composite         O
+	ConnectionDetails []xfnv1alpha1.ExplicitConnectionDetail
 }
 
 // GetFromKubeObject gets the k8s resource o from a provider kubernetes object kon (Kube Object Name)
 // from the observed array of the FunctionIO.
-func (o *ObservedResources) GetFromKubeObject(ctx context.Context, obj client.Object, kon string) error {
-	ko, err := getKubeObjectFrom(ctx, o.resources, obj, kon)
+func (o *ObservedResources[T, O]) GetFromKubeObject(ctx context.Context, obj client.Object, kon string) error {
+	ko, err := getKubeObjectFrom(ctx, o.Resources, obj, kon)
 	if err != nil {
 		return err
 	}
@@ -22,8 +27,8 @@ func (o *ObservedResources) GetFromKubeObject(ctx context.Context, obj client.Ob
 
 // GetManagedResource will unmarshall the managed resource with the given name into the given object.
 // It reads from the Observed array.
-func (o *ObservedResources) GetManagedResource(resName string, obj client.Object) error {
-	return getFrom(o.resources, obj, resName)
+func (o *ObservedResources[T, O]) GetManagedResource(resName string, obj client.Object) error {
+	return getFrom(o.Resources, obj, resName)
 }
 
 // observedResource is a wrapper around xfnv1alpha1.ObservedResource

--- a/runtime/observed.go
+++ b/runtime/observed.go
@@ -20,7 +20,7 @@ func (o *ObservedResources) GetFromKubeObject(ctx context.Context, obj client.Ob
 	if err != nil {
 		return err
 	}
-	return fromKubeObject(ko, obj)
+	return fromKubeObject(ctx, ko, obj)
 }
 
 // GetManagedResource unmarshalls the managed resource with the given name into the given object.
@@ -44,7 +44,7 @@ func (o *ObservedResources) GetCompositeConnectionDetails(_ context.Context) *[]
 }
 
 // ListResources return the list of managed resources from observed object
-func (o *ObservedResources) ListResources() []Resource {
+func (o *ObservedResources) ListResources(_ context.Context) []Resource {
 	return o.resources
 }
 

--- a/runtime/observed.go
+++ b/runtime/observed.go
@@ -10,15 +10,15 @@ type ObservedResources[T any, O interface {
 	client.Object
 	*T
 }] struct {
-	Resources         *[]Resource
-	Composite         O
+	Resources         []Resource
+	Composite         T
 	ConnectionDetails []xfnv1alpha1.ExplicitConnectionDetail
 }
 
 // GetFromKubeObject gets the k8s resource o from a provider kubernetes object kon (Kube Object Name)
 // from the observed array of the FunctionIO.
 func (o *ObservedResources[T, O]) GetFromKubeObject(ctx context.Context, obj client.Object, kon string) error {
-	ko, err := getKubeObjectFrom(ctx, o.Resources, obj, kon)
+	ko, err := getKubeObjectFrom(ctx, &o.Resources, obj, kon)
 	if err != nil {
 		return err
 	}
@@ -28,7 +28,7 @@ func (o *ObservedResources[T, O]) GetFromKubeObject(ctx context.Context, obj cli
 // GetManagedResource will unmarshall the managed resource with the given name into the given object.
 // It reads from the Observed array.
 func (o *ObservedResources[T, O]) GetManagedResource(resName string, obj client.Object) error {
-	return getFrom(o.Resources, obj, resName)
+	return getFrom(&o.Resources, obj, resName)
 }
 
 // observedResource is a wrapper around xfnv1alpha1.ObservedResource
@@ -37,14 +37,14 @@ type observedResource struct {
 	xfnv1alpha1.ObservedResource
 }
 
-func (o *observedResource) GetName() string {
+func (o observedResource) GetName() string {
 	return o.Name
 }
 
-func (o *observedResource) GetRaw() []byte {
+func (o observedResource) GetRaw() []byte {
 	return o.Resource.Raw
 }
 
-func (o *observedResource) SetRaw(raw []byte) {
+func (o observedResource) SetRaw(raw []byte) {
 	o.Resource.Raw = raw
 }

--- a/runtime/observed.go
+++ b/runtime/observed.go
@@ -1,0 +1,45 @@
+package runtime
+
+import (
+	"context"
+	xfnv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ObservedResources struct {
+	resources *[]Resource
+}
+
+// GetFromKubeObject gets the k8s resource o from a provider kubernetes object kon (Kube Object Name)
+// from the observed array of the FunctionIO.
+func (o *ObservedResources) GetFromKubeObject(ctx context.Context, obj client.Object, kon string) error {
+	ko, err := getKubeObjectFrom(ctx, o.resources, obj, kon)
+	if err != nil {
+		return err
+	}
+	return fromKubeObject(ko, obj)
+}
+
+// GetManagedResource will unmarshall the managed resource with the given name into the given object.
+// It reads from the Observed array.
+func (o *ObservedResources) GetManagedResource(resName string, obj client.Object) error {
+	return getFrom(o.resources, obj, resName)
+}
+
+// observedResource is a wrapper around xfnv1alpha1.ObservedResource
+// so we can satisfy the Resource interface.
+type observedResource struct {
+	xfnv1alpha1.ObservedResource
+}
+
+func (o *observedResource) GetName() string {
+	return o.Name
+}
+
+func (o *observedResource) GetRaw() []byte {
+	return o.Resource.Raw
+}
+
+func (o *observedResource) SetRaw(raw []byte) {
+	o.Resource.Raw = raw
+}

--- a/runtime/observed.go
+++ b/runtime/observed.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	xfnv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,9 +34,7 @@ func (o *ObservedResources[T, O]) GetManagedResource(resName string, obj client.
 
 // observedResource is a wrapper around xfnv1alpha1.ObservedResource
 // so we can satisfy the Resource interface.
-type observedResource struct {
-	xfnv1alpha1.ObservedResource
-}
+type observedResource xfnv1alpha1.ObservedResource
 
 func (o observedResource) GetName() string {
 	return o.Name
@@ -47,4 +46,8 @@ func (o observedResource) GetRaw() []byte {
 
 func (o observedResource) SetRaw(raw []byte) {
 	o.Resource.Raw = raw
+}
+
+func (o observedResource) GetKind() schema.ObjectKind {
+	return o.Resource.Object.GetObjectKind()
 }

--- a/runtime/observed.go
+++ b/runtime/observed.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 	xfnv1alpha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,7 +18,7 @@ type ObservedResources[T any, O interface {
 // GetFromKubeObject gets the k8s resource o from a provider kubernetes object kon (Kube Object Name)
 // from the observed array of the FunctionIO.
 func (o *ObservedResources[T, O]) GetFromKubeObject(ctx context.Context, obj client.Object, kon string) error {
-	ko, err := getKubeObjectFrom(ctx, &o.Resources, obj, kon)
+	ko, err := getKubeObjectFrom(ctx, &o.Resources, kon)
 	if err != nil {
 		return err
 	}
@@ -28,8 +27,8 @@ func (o *ObservedResources[T, O]) GetFromKubeObject(ctx context.Context, obj cli
 
 // GetManagedResource will unmarshall the managed resource with the given name into the given object.
 // It reads from the Observed array.
-func (o *ObservedResources[T, O]) GetManagedResource(resName string, obj client.Object) error {
-	return getFrom(&o.Resources, obj, resName)
+func (o *ObservedResources[T, O]) GetManagedResource(ctx context.Context, resName string, obj client.Object) error {
+	return getFrom(ctx, &o.Resources, obj, resName)
 }
 
 // observedResource is a wrapper around xfnv1alpha1.ObservedResource
@@ -46,8 +45,4 @@ func (o observedResource) GetRaw() []byte {
 
 func (o observedResource) SetRaw(raw []byte) {
 	o.Resource.Raw = raw
-}
-
-func (o observedResource) GetKind() schema.ObjectKind {
-	return o.Resource.Object.GetObjectKind()
 }

--- a/runtime/observed.go
+++ b/runtime/observed.go
@@ -16,20 +16,25 @@ type ObservedResources struct {
 	composite xfnv1alpha1.ObservedComposite
 }
 
-// GetFromKubeObject gets the k8s resource o from a provider kubernetes object kon (Kube Object Name)
+// List return the list of managed resources from observed object
+func (o *ObservedResources) List(_ context.Context) []Resource {
+	return o.resources
+}
+
+// Get unmarshalls the managed resource with the given name into the given object.
+// It reads from the Observed array.
+func (o *ObservedResources) Get(ctx context.Context, obj client.Object, resName string) error {
+	return getFrom(ctx, &o.resources, obj, resName)
+}
+
+// GetFromObject gets the k8s resource o from a provider kubernetes object kon (Kube Object Name)
 // from the observed array of the FunctionIO.
-func (o *ObservedResources) GetFromKubeObject(ctx context.Context, obj client.Object, kon string) error {
+func (o *ObservedResources) GetFromObject(ctx context.Context, obj client.Object, kon string) error {
 	ko, err := getKubeObjectFrom(ctx, &o.resources, kon)
 	if err != nil {
 		return err
 	}
 	return o.fromKubeObject(ctx, ko, obj)
-}
-
-// GetManagedResource unmarshalls the managed resource with the given name into the given object.
-// It reads from the Observed array.
-func (o *ObservedResources) GetManagedResource(ctx context.Context, obj client.Object, resName string) error {
-	return getFrom(ctx, &o.resources, obj, resName)
 }
 
 // GetComposite unmarshalls the observed composite from the function io to the given object.
@@ -44,11 +49,6 @@ func (o *ObservedResources) GetComposite(_ context.Context, obj client.Object) e
 // GetCompositeConnectionDetails returns the connection details of the observed composite
 func (o *ObservedResources) GetCompositeConnectionDetails(_ context.Context) *[]xfnv1alpha1.ExplicitConnectionDetail {
 	return &o.composite.ConnectionDetails
-}
-
-// ListResources return the list of managed resources from observed object
-func (o *ObservedResources) ListResources(_ context.Context) []Resource {
-	return o.resources
 }
 
 // fromKubeObject checks into status field instead of spec. The spec may not show all the relevant data

--- a/runtime/observed.go
+++ b/runtime/observed.go
@@ -25,7 +25,7 @@ func (o *ObservedResources) GetFromKubeObject(ctx context.Context, obj client.Ob
 
 // GetManagedResource unmarshalls the managed resource with the given name into the given object.
 // It reads from the Observed array.
-func (o *ObservedResources) GetManagedResource(ctx context.Context, resName string, obj client.Object) error {
+func (o *ObservedResources) GetManagedResource(ctx context.Context, obj client.Object, resName string) error {
 	return getFrom(ctx, &o.resources, obj, resName)
 }
 

--- a/runtime/observed.go
+++ b/runtime/observed.go
@@ -23,13 +23,13 @@ func (o *ObservedResources) GetFromKubeObject(ctx context.Context, obj client.Ob
 	return fromKubeObject(ko, obj)
 }
 
-// GetManagedResource will unmarshall the managed resource with the given name into the given object.
+// GetManagedResource unmarshalls the managed resource with the given name into the given object.
 // It reads from the Observed array.
 func (o *ObservedResources) GetManagedResource(ctx context.Context, resName string, obj client.Object) error {
 	return getFrom(ctx, &o.resources, obj, resName)
 }
 
-// GetComposite will unmarshall the observed composite from the function io to the given object.
+// GetComposite unmarshalls the observed composite from the function io to the given object.
 func (o *ObservedResources) GetComposite(_ context.Context, obj client.Object) error {
 	err := json.Unmarshal(o.composite.Resource.Raw, obj)
 	if err != nil {
@@ -38,9 +38,14 @@ func (o *ObservedResources) GetComposite(_ context.Context, obj client.Object) e
 	return nil
 }
 
-// GetCompositeConnectionDetails will return the connection details of the observed composite
+// GetCompositeConnectionDetails returns the connection details of the observed composite
 func (o *ObservedResources) GetCompositeConnectionDetails(_ context.Context) *[]xfnv1alpha1.ExplicitConnectionDetail {
 	return &o.composite.ConnectionDetails
+}
+
+// ListResources return the list of managed resources from observed object
+func (o *ObservedResources) ListResources() []Resource {
+	return o.resources
 }
 
 // observedResource is a wrapper around xfnv1alpha1.ObservedResource

--- a/runtime/observed.go
+++ b/runtime/observed.go
@@ -10,7 +10,7 @@ import (
 
 type ObservedResources struct {
 	resources []Resource
-	composite *xfnv1alpha1.ObservedComposite
+	composite xfnv1alpha1.ObservedComposite
 }
 
 // GetFromKubeObject gets the k8s resource o from a provider kubernetes object kon (Kube Object Name)

--- a/runtime/result.go
+++ b/runtime/result.go
@@ -1,6 +1,10 @@
 package runtime
 
-import "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
+import (
+	"context"
+	"github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+)
 
 type Result interface {
 	Resolve() v1alpha1.Result
@@ -11,7 +15,8 @@ type result v1alpha1.Result
 // NewWarning results are non-fatal; the entire Composition will run to
 // completion but warning events and debug logs associated with the
 // composite resource will be emitted.
-func NewWarning(msg string) Result {
+func NewWarning(ctx context.Context, msg string) Result {
+	controllerruntime.LoggerFrom(ctx).Info(msg)
 	return result{
 		Severity: v1alpha1.SeverityWarning,
 		Message:  msg,
@@ -21,7 +26,19 @@ func NewWarning(msg string) Result {
 // NewFatal results are fatal; subsequent Composition Functions may run, but
 // the Composition Function pipeline run will be considered a failure and
 // the first error will be returned.
-func NewFatal(msg string) Result {
+func NewFatalErr(ctx context.Context, msg string, err error) Result {
+	controllerruntime.LoggerFrom(ctx).Error(err, msg)
+	return result{
+		Severity: v1alpha1.SeverityFatal,
+		Message:  msg,
+	}
+}
+
+// NewFatalNoError results are fatal; subsequent Composition Functions may run, but
+// the Composition Function pipeline run will be considered a failure and
+// the first error will be returned.
+func NewFatal(ctx context.Context, msg string) Result {
+	controllerruntime.LoggerFrom(ctx).Info(msg)
 	return result{
 		Severity: v1alpha1.SeverityFatal,
 		Message:  msg,

--- a/runtime/result.go
+++ b/runtime/result.go
@@ -1,0 +1,43 @@
+package runtime
+
+import "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
+
+type Result interface {
+	Resolve() v1alpha1.Result
+}
+
+type result v1alpha1.Result
+
+// NewWarning results are non-fatal; the entire Composition will run to
+// completion but warning events and debug logs associated with the
+// composite resource will be emitted.
+func NewWarning(msg string) Result {
+	return result{
+		Severity: v1alpha1.SeverityWarning,
+		Message:  msg,
+	}
+}
+
+// NewFatal results are fatal; subsequent Composition Functions may run, but
+// the Composition Function pipeline run will be considered a failure and
+// the first error will be returned.
+func NewFatal(msg string) Result {
+	return result{
+		Severity: v1alpha1.SeverityFatal,
+		Message:  msg,
+	}
+}
+
+// NewNormal results are emitted as normal events and debug logs associated
+// with the composite resource.
+func NewNormal() Result {
+	return result{
+		Severity: v1alpha1.SeverityNormal,
+		Message:  "function ran successfully",
+	}
+}
+
+// Resolve returns the wrapped object v1alpha1.Result from crossplane
+func (r result) Resolve() v1alpha1.Result {
+	return v1alpha1.Result(r)
+}

--- a/runtime/result.go
+++ b/runtime/result.go
@@ -12,9 +12,9 @@ type Result interface {
 
 type result v1alpha1.Result
 
-// NewWarning results are non-fatal; the entire Composition will run to
-// completion but warning events and debug logs associated with the
-// composite resource will be emitted.
+// NewWarning returns a warning Result from a message string. The entire
+// Composition will run to completion but warning events and debug logs
+// associated with the composite resource will be emitted.
 func NewWarning(ctx context.Context, msg string) Result {
 	controllerruntime.LoggerFrom(ctx).Info(msg)
 	return result{
@@ -23,9 +23,9 @@ func NewWarning(ctx context.Context, msg string) Result {
 	}
 }
 
-// NewFatal results are fatal; subsequent Composition Functions may run, but
-// the Composition Function pipeline run will be considered a failure and
-// the first error will be returned.
+// NewFatalErr returns a fatal Result from a message string and an error. The result is fatal,
+// subsequent Composition Functions may run, but the Composition Function pipeline run
+// will be considered a failure and the first error will be returned.
 func NewFatalErr(ctx context.Context, msg string, err error) Result {
 	controllerruntime.LoggerFrom(ctx).Error(err, msg)
 	return result{
@@ -34,9 +34,9 @@ func NewFatalErr(ctx context.Context, msg string, err error) Result {
 	}
 }
 
-// NewFatalNoError results are fatal; subsequent Composition Functions may run, but
-// the Composition Function pipeline run will be considered a failure and
-// the first error will be returned.
+// NewFatal returns a fatal Result from a message string. The result is fatal,
+// subsequent Composition Functions may run, but the Composition Function
+// pipeline run will be considered a failure and the first error will be returned.
 func NewFatal(ctx context.Context, msg string) Result {
 	controllerruntime.LoggerFrom(ctx).Info(msg)
 	return result{

--- a/runtime/run.go
+++ b/runtime/run.go
@@ -19,7 +19,7 @@ func Exec[T any, O interface {
 }](ctx context.Context, log logr.Logger, runtime *Runtime[T, O], transform Transform[T, O]) error {
 
 	log.V(1).Info("Executing transformation function")
-	res := transform.TransformFunc(ctx, log, runtime).Resolve()
+	res := transform.TransformFunc(ctx, runtime).Resolve()
 	if res.Severity == xfnv1alpha1.SeverityNormal {
 		res.Message = fmt.Sprintf("Function %s ran successfully", transform.Name)
 	}

--- a/runtime/run.go
+++ b/runtime/run.go
@@ -19,16 +19,14 @@ func Exec(ctx context.Context, log logr.Logger, runtime *Runtime, transform Tran
 		res.Message = fmt.Sprintf("Function %s ran successfully", transform.Name)
 	}
 	runtime.io.Results = append(runtime.io.Results, res)
-	/*
-		runtime.io.Desired.Composite.Resource.Raw = runtime.Desired.composite.Resource.Raw
-		runtime.io.Desired.Composite.ConnectionDetails = runtime.Desired.composite.ConnectionDetails
 
-		runtime.io.Desired.Resources = make([]xfnv1alpha1.DesiredResource, len(runtime.Desired.resources))
-		for i, r := range runtime.Desired.resources {
-			runtime.io.Desired.Resources[i] = xfnv1alpha1.DesiredResource(r.(desiredResource))
-		}
+	runtime.io.Desired.Composite.Resource.Raw = runtime.Desired.composite.Resource.Raw
+	runtime.io.Desired.Composite.ConnectionDetails = runtime.Desired.composite.ConnectionDetails
 
-	*/
+	runtime.io.Desired.Resources = make([]xfnv1alpha1.DesiredResource, len(runtime.Desired.resources))
+	for i, r := range runtime.Desired.resources {
+		runtime.io.Desired.Resources[i] = xfnv1alpha1.DesiredResource(r.(desiredResource))
+	}
 
 	return nil
 }

--- a/runtime/run.go
+++ b/runtime/run.go
@@ -21,7 +21,7 @@ func Exec[T any, O interface {
 	log.V(1).Info("Executing transformation function")
 	err := transform.TransformFunc(ctx, log, runtime)
 	if err != nil {
-		runtime.AddResult(xfnv1alpha1.SeverityWarning, err.Error())
+		runtime.addResult(xfnv1alpha1.SeverityWarning, err.Error())
 	}
 
 	log.V(1).Info("Marshalling desired composite")

--- a/runtime/run.go
+++ b/runtime/run.go
@@ -19,10 +19,11 @@ func Exec[T any, O interface {
 }](ctx context.Context, log logr.Logger, runtime *Runtime[T, O], transform Transform[T, O]) error {
 
 	log.V(1).Info("Executing transformation function")
-	err := transform.TransformFunc(ctx, log, runtime)
-	if err != nil {
-		runtime.addResult(xfnv1alpha1.SeverityWarning, err.Error())
+	res := transform.TransformFunc(ctx, log, runtime).Resolve()
+	if res.Severity == xfnv1alpha1.SeverityNormal {
+		res.Message = fmt.Sprintf("Function %s ran successfully", transform.Name)
 	}
+	runtime.io.Results = append(runtime.io.Results, res)
 
 	log.V(1).Info("Marshalling desired composite")
 	dRaw, err := json.Marshal(runtime.Desired.Composite)

--- a/runtime/run.go
+++ b/runtime/run.go
@@ -21,7 +21,7 @@ func Exec[T any, O interface {
 	log.V(1).Info("Unmarshalling composite from FunctionIO")
 	var t T
 	obj := &t
-	err := json.Unmarshal(iof.Observed.Composite.Resource.Raw, obj)
+	err := json.Unmarshal(iof.Func.Observed.Composite.Resource.Raw, obj)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal composite: %w", err)
 	}
@@ -37,7 +37,7 @@ func Exec[T any, O interface {
 	if err != nil {
 		return fmt.Errorf("failed to marshal composite: %w", err)
 	}
-	iof.Desired.Composite.Resource.Raw = raw
+	iof.Func.Desired.Composite.Resource.Raw = raw
 
 	return nil
 }
@@ -46,7 +46,7 @@ func Exec[T any, O interface {
 // pick it up again.
 func printFunctionIO(iof *Runtime, log logr.Logger) error {
 	log.V(1).Info("Marshalling FunctionIO")
-	fnc, err := yaml.Marshal(iof)
+	fnc, err := yaml.Marshal(iof.Func)
 	if err != nil {
 		return fmt.Errorf("failed to marshal function io: %w", err)
 	}
@@ -93,7 +93,7 @@ func RunCommand[T any, O interface {
 
 func setup(ctx *cli.Context) (*Runtime, error) {
 
-	funcIO, err := getFunctionIO(ctx.Context)
+	funcIO, err := NewRuntime(ctx.Context)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -64,11 +64,11 @@ func NewRuntime(ctx context.Context) (*Runtime, error) {
 	}
 	r.Observed = ObservedResources{
 		resources: *observedResources(r.io.Observed.Resources),
-		composite: &r.io.Observed.Composite,
+		composite: r.io.Observed.Composite,
 	}
 	r.Desired = DesiredResources{
 		resources: *desiredResources(r.io.Desired.Resources),
-		composite: &r.io.Desired.Composite,
+		composite: r.io.Desired.Composite,
 	}
 
 	return &r, nil

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -172,15 +172,6 @@ func updateKubeObject(obj client.Object, ko *xkube.Object) error {
 	return nil
 }
 
-// AddResult will add a new result to the results array.
-// These results will generate events on the composite.
-func (r *Runtime[T, O]) addResult(severity xfnv1alpha1.Severity, message string) {
-	r.io.Results = append(r.io.Results, xfnv1alpha1.Result{
-		Severity: severity,
-		Message:  message,
-	})
-}
-
 // AddToScheme adds given SchemeBuilder to the Scheme.
 func AddToScheme(obj runtime.SchemeBuilder) error {
 	return obj.AddToScheme(s)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"os"
-	"reflect"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -73,18 +72,6 @@ func NewRuntime(ctx context.Context) (*Runtime, error) {
 	}
 
 	return &r, nil
-}
-
-func fromKubeObject(ctx context.Context, kobj *xkube.Object, obj client.Object) error {
-	log := controllerruntime.LoggerFrom(ctx)
-	log.V(1).Info("Unmarshalling resource from kube object", "kube object", kobj, reflect.TypeOf(obj).Kind())
-	if kobj.Status.AtProvider.Manifest.Raw == nil {
-		if kobj.Spec.ForProvider.Manifest.Raw == nil {
-			return fmt.Errorf("no resource in kubernetes object")
-		}
-		return json.Unmarshal(kobj.Spec.ForProvider.Manifest.Raw, obj)
-	}
-	return json.Unmarshal(kobj.Status.AtProvider.Manifest.Raw, obj)
 }
 
 func getKubeObjectFrom(ctx context.Context, resources *[]Resource, kon string) (*xkube.Object, error) {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -92,7 +92,10 @@ func NewRuntime[T any, O interface {
 
 func fromKubeObject(kobj *xkube.Object, obj client.Object) error {
 	if kobj.Status.AtProvider.Manifest.Raw == nil {
-		return fmt.Errorf("no resource in kubernetes object")
+		if kobj.Spec.ForProvider.Manifest.Raw == nil {
+			return fmt.Errorf("no resource in kubernetes object")
+		}
+		return json.Unmarshal(kobj.Spec.ForProvider.Manifest.Raw, obj)
 	}
 	return json.Unmarshal(kobj.Status.AtProvider.Manifest.Raw, obj)
 }
@@ -149,7 +152,7 @@ func observedResources(or []xfnv1alpha1.ObservedResource) *[]Resource {
 	resources := make([]Resource, len(or))
 
 	for i := range or {
-		resources[i] = &observedResource{ObservedResource: or[i]}
+		resources[i] = observedResource(or[i])
 	}
 
 	return &resources

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -67,8 +67,8 @@ func NewRuntime[T any, O interface {
 	log.V(1).Info("Unmarshalling FunctionIO from stdin")
 	r := Runtime[T, O]{}
 	err = yaml.Unmarshal(x, &r.io)
-	r.Observed = ObservedResources[T, O]{Resources: observedResources(r.io.Observed.Resources)}
-	r.Desired = DesiredResources[T, O]{Resources: desiredResources(r.io.Desired.Resources)}
+	r.Observed = ObservedResources[T, O]{Resources: *observedResources(r.io.Observed.Resources)}
+	r.Desired = DesiredResources[T, O]{Resources: *desiredResources(r.io.Desired.Resources)}
 
 	log.V(1).Info("Unmarshalling observed composite from FunctionIO")
 	var o T
@@ -77,7 +77,7 @@ func NewRuntime[T any, O interface {
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal composite: %w", err)
 	}
-	r.Observed.Composite = observed
+	r.Observed.Composite = *observed
 
 	log.V(1).Info("Unmarshalling desired composite from FunctionIO")
 	var d T
@@ -86,7 +86,7 @@ func NewRuntime[T any, O interface {
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal composite: %w", err)
 	}
-	r.Desired.Composite = desired
+	r.Desired.Composite = *desired
 
 	return &r, nil
 }
@@ -141,7 +141,7 @@ func desiredResources(dr []xfnv1alpha1.DesiredResource) *[]Resource {
 	resources := make([]Resource, len(dr))
 
 	for i := range dr {
-		resources[i] = &desiredResource{DesiredResource: dr[i]}
+		resources[i] = desiredResource(dr[i])
 	}
 
 	return &resources

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -66,6 +66,9 @@ func NewRuntime[T any, O interface {
 	log.V(1).Info("Unmarshalling FunctionIO from stdin")
 	r := Runtime[T, O]{}
 	err = yaml.Unmarshal(x, &r.io)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal function io: %w", err)
+	}
 	r.Observed = ObservedResources[T, O]{Resources: *observedResources(r.io.Observed.Resources)}
 	r.Desired = DesiredResources[T, O]{Resources: *desiredResources(r.io.Desired.Resources)}
 

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -2,8 +2,6 @@ package runtime
 
 import (
 	"context"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // AppInfo defines application information
@@ -12,10 +10,7 @@ type AppInfo struct {
 }
 
 // Transform specifies a transformation function to be run against the given FunctionIO.
-type Transform[T any, O interface {
-	client.Object
-	*T
-}] struct {
+type Transform struct {
 	Name          string
-	TransformFunc func(c context.Context, io *Runtime[T, O]) Result
+	TransformFunc func(c context.Context, io *Runtime) Result
 }

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -18,5 +17,5 @@ type Transform[T any, O interface {
 	*T
 }] struct {
 	Name          string
-	TransformFunc func(c context.Context, log logr.Logger, io *Runtime[T, O]) Result
+	TransformFunc func(c context.Context, io *Runtime[T, O]) Result
 }

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -18,5 +18,5 @@ type Transform[T any, O interface {
 	*T
 }] struct {
 	Name          string
-	TransformFunc func(c context.Context, log logr.Logger, io *Runtime[T, O]) error
+	TransformFunc func(c context.Context, log logr.Logger, io *Runtime[T, O]) Result
 }

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -18,5 +18,5 @@ type Transform[T any, O interface {
 	*T
 }] struct {
 	Name          string
-	TransformFunc func(c context.Context, log logr.Logger, io *Runtime, obj O) (O, error)
+	TransformFunc func(c context.Context, log logr.Logger, io *Runtime[T, O]) error
 }

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -34,6 +34,19 @@ observed:
           name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
         compositionUpdatePolicy: Automatic
         parameters:
+          monitoring:
+            alertmanagerConfigSecretRef: test
+            alertmanagerConfigTemplate:
+              route:
+                groupBy: [ 'job' ]
+                groupWait: 30s
+                groupInterval: 5m
+                repeatInterval: 12h
+                receiver: 'webhook'
+              receivers:
+                - name: 'webhook'
+                  webhookConfigs:
+                    - url: 'http://example.com/'
           backup:
             retention: 6
             schedule: 0 22 * * *


### PR DESCRIPTION
## Summary

* This PR is suppose to improve overall library and make it even easier to add new composition functions.

## Runtime
This PR further improves the current runtime library by wrapping the function-io from crossplane and allowing organised access to `desired` and `observed` resources via carefully implemented methods. Also the generic part has been removed due to excessive complexity for little gain. The composites can be accessed now from either `desired` and `observed` objects.

### First look

* I will try to get rid off original go `Function IO` from `runtime` object and substitute it with wrapped structures which have useful methods. The `Function IO` object I believe should be completely abstracted away from the `transform` go function that someone adds with a new composition function.

### Second look

* I decided to remove context and log objects from the application as it does not add much value for us. The function io side car does not print logs for us therefore I concentrated the efforts onto the saving the errors in the Results array of the functionio.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
