### PR TITLE
Add randomized defaults for maintenance and backup of VSHNPostgresql

### DIFF
--- a/functions/vshn-postgres-func/schedule.go
+++ b/functions/vshn-postgres-func/schedule.go
@@ -1,0 +1,56 @@
+package vshnpostgres
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/vshn/appcat-comp-functions/runtime"
+	vshnv1 "github.com/vshn/component-appcat/apis/vshn/v1"
+)
+
+var (
+	maitenanceWindowStart = time.Date(1970, 1, 1, 21, 0, 0, 0, time.UTC)
+	maitenanceWindowEnd   = time.Date(1970, 1, 2, 5, 0, 0, 0, time.UTC)
+	maitenanceWindowRange = maitenanceWindowEnd.Unix() - maitenanceWindowStart.Unix()
+)
+
+// TransformSchedule initializes the backup and maintenance schedules  if the user did not explicitly provide a schedule.
+// The maintenance will be set to a random time on Tuesday night between 21:00 and 5:00, and the backup schedule will be set to once a day between 20:00 and 4:00.
+// If neither maintenance nor backup is set, the function will make sure that there will be backup scheduled one hour before the maintenance.
+func TransformSchedule(ctx context.Context, iof *runtime.Runtime) runtime.Result {
+
+	comp := vshnv1.VSHNPostgreSQL{}
+	err := iof.Desired.GetComposite(ctx, &comp)
+	if err != nil {
+		return runtime.NewFatalErr(ctx, "failed to parse composite", err)
+	}
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	maintTime := time.Unix(maitenanceWindowStart.Unix()+rng.Int63n(maitenanceWindowRange), 0).In(time.UTC)
+	backupTime := maintTime.Add(-1 * time.Hour).In(time.UTC)
+
+	if comp.Spec.Parameters.Backup.Schedule == "" {
+		comp.Spec.Parameters.Backup.Schedule = fmt.Sprintf("%d %d * * *", backupTime.Minute(), backupTime.Hour())
+	}
+
+	if comp.Spec.Parameters.Maintenance.TimeOfDay == "" {
+		comp.Spec.Parameters.Maintenance.TimeOfDay = maintTime.Format(time.TimeOnly)
+	}
+
+	if comp.Spec.Parameters.Maintenance.DayOfWeek == "" {
+		day := "tuesday"
+		if maintTime.Day() > 1 {
+			day = "wednesday"
+		}
+		comp.Spec.Parameters.Maintenance.DayOfWeek = day
+	}
+
+	err = iof.Desired.SetComposite(ctx, &comp)
+	if err != nil {
+		return runtime.NewFatalErr(ctx, "failed to set composite", err)
+	}
+
+	return runtime.NewNormal()
+}

--- a/functions/vshn-postgres-func/schedule_test.go
+++ b/functions/vshn-postgres-func/schedule_test.go
@@ -1,0 +1,167 @@
+package vshnpostgres
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	vshnv1 "github.com/vshn/component-appcat/apis/vshn/v1"
+
+	fnv1aplha1 "github.com/crossplane/crossplane/apis/apiextensions/fn/io/v1alpha1"
+)
+
+func TestTransformSchedule_SetRandomSchedule(t *testing.T) {
+
+	for i := 0; i < 50; i++ {
+		t.Run(fmt.Sprintf("Round %d", i), func(t *testing.T) {
+			iof := loadRuntimeFromFile(t, "base.yaml")
+
+			res := TransformSchedule(context.TODO(), iof)
+			assert.Equal(t, fnv1aplha1.SeverityNormal, res.Resolve().Severity)
+
+			out := &vshnv1.VSHNPostgreSQL{}
+			err := iof.Desired.GetComposite(context.TODO(), out)
+			assert.NoError(t, err)
+
+			backupTime := parseAndValidateBackupSchedule(t, out)
+			maintTime := parseAndValidateMaitenance(t, out)
+
+			t.Logf("Backup Time: %q\n", backupTime.Format(time.RFC3339))
+			t.Logf("Maintenance Time: %q\n", maintTime.Format(time.RFC3339))
+
+			diff := maintTime.Truncate(time.Minute).Sub(backupTime)
+			assert.Equal(t, time.Hour, diff)
+		})
+	}
+
+}
+
+func TestTransformSchedule_DontOverwriteBackup(t *testing.T) {
+	iof := loadRuntimeFromFile(t, "base.yaml")
+
+	comp := &vshnv1.VSHNPostgreSQL{}
+	err := iof.Desired.GetComposite(context.TODO(), comp)
+	assert.NoError(t, err)
+	comp.Spec.Parameters.Backup.Schedule = "3 2 * * *"
+	err = iof.Desired.SetComposite(context.TODO(), comp)
+	assert.NoError(t, err)
+
+	res := TransformSchedule(context.TODO(), iof)
+	assert.Equal(t, fnv1aplha1.SeverityNormal, res.Resolve().Severity)
+
+	err = iof.Desired.GetComposite(context.TODO(), comp)
+	assert.NoError(t, err)
+	assert.Equal(t, "3 2 * * *", comp.Spec.Parameters.Backup.Schedule)
+
+	_ = parseAndValidateMaitenance(t, comp)
+}
+
+func TestTransformSchedule_DontOverwriteMaitenance(t *testing.T) {
+	iof := loadRuntimeFromFile(t, "base.yaml")
+
+	comp := &vshnv1.VSHNPostgreSQL{}
+	err := iof.Desired.GetComposite(context.TODO(), comp)
+	assert.NoError(t, err)
+	comp.Spec.Parameters.Maintenance.DayOfWeek = "thursday"
+	comp.Spec.Parameters.Maintenance.TimeOfDay = "11:12:23"
+	err = iof.Desired.SetComposite(context.TODO(), comp)
+	assert.NoError(t, err)
+
+	res := TransformSchedule(context.TODO(), iof)
+	assert.Equal(t, fnv1aplha1.SeverityNormal, res.Resolve().Severity)
+
+	err = iof.Desired.GetComposite(context.TODO(), comp)
+	assert.NoError(t, err)
+	assert.Equal(t, "thursday", comp.Spec.Parameters.Maintenance.DayOfWeek)
+	assert.Equal(t, "11:12:23", comp.Spec.Parameters.Maintenance.TimeOfDay)
+
+	_ = parseAndValidateBackupSchedule(t, comp)
+}
+
+func TestTransformSchedule_DontOverwriteBackupOrMaintenance(t *testing.T) {
+	iof := loadRuntimeFromFile(t, "base.yaml")
+
+	comp := &vshnv1.VSHNPostgreSQL{}
+	err := iof.Desired.GetComposite(context.TODO(), comp)
+	assert.NoError(t, err)
+	comp.Spec.Parameters.Backup.Schedule = "3 2 * * *"
+	comp.Spec.Parameters.Maintenance.DayOfWeek = "thursday"
+	comp.Spec.Parameters.Maintenance.TimeOfDay = "11:12:23"
+	err = iof.Desired.SetComposite(context.TODO(), comp)
+	assert.NoError(t, err)
+
+	res := TransformSchedule(context.TODO(), iof)
+	assert.Equal(t, fnv1aplha1.SeverityNormal, res.Resolve().Severity)
+
+	err = iof.Desired.GetComposite(context.TODO(), comp)
+	assert.NoError(t, err)
+	assert.Equal(t, "3 2 * * *", comp.Spec.Parameters.Backup.Schedule)
+	assert.Equal(t, "thursday", comp.Spec.Parameters.Maintenance.DayOfWeek)
+	assert.Equal(t, "11:12:23", comp.Spec.Parameters.Maintenance.TimeOfDay)
+}
+
+func parseAndValidateBackupSchedule(t *testing.T, comp *vshnv1.VSHNPostgreSQL) time.Time {
+	var backupTime time.Time
+	t.Run("validateBackupSchedule", func(t *testing.T) {
+		t.Logf("backup schedule %q", comp.Spec.Parameters.Backup.Schedule)
+
+		assert.NotEmpty(t, comp.Spec.Parameters.Backup.Schedule)
+		backupSchedule := strings.Fields(comp.Spec.Parameters.Backup.Schedule)
+		assert.Equal(t, "*", backupSchedule[4])
+		assert.Equal(t, "*", backupSchedule[3])
+		assert.Equal(t, "*", backupSchedule[2])
+
+		backupMinute, err := strconv.Atoi(backupSchedule[0])
+		assert.NoError(t, err)
+		assert.Less(t, backupMinute, 60)
+		assert.GreaterOrEqual(t, backupMinute, 0)
+		backupHour, err := strconv.Atoi(backupSchedule[1])
+		assert.Less(t, backupHour, 24)
+		assert.GreaterOrEqual(t, backupHour, 0)
+		assert.NoError(t, err)
+		backupDay := 1
+		if backupHour < 6 {
+			backupDay = 2
+		}
+		backupTime = time.Date(0, 1, backupDay, backupHour, backupMinute, 0, 0, time.UTC)
+
+		backupWindowStart := time.Date(0, 1, 1, 20, 0, 0, 0, time.UTC)
+		backupWindowEnd := time.Date(0, 1, 2, 4, 0, 0, 0, time.UTC)
+		assert.LessOrEqual(t, backupWindowStart, backupTime)
+		assert.LessOrEqual(t, backupTime, backupWindowEnd)
+
+	})
+	return backupTime
+}
+
+func parseAndValidateMaitenance(t *testing.T, comp *vshnv1.VSHNPostgreSQL) time.Time {
+	var maintTime time.Time
+	t.Run("validateMaintenanceSchedule", func(t *testing.T) {
+
+		t.Logf("maintenance time %q", comp.Spec.Parameters.Maintenance.TimeOfDay)
+		t.Logf("maintenance day %q", comp.Spec.Parameters.Maintenance.DayOfWeek)
+
+		var err error
+		assert.NotEmpty(t, comp.Spec.Parameters.Maintenance.TimeOfDay)
+		maintTime, err = time.ParseInLocation(time.TimeOnly, comp.Spec.Parameters.Maintenance.TimeOfDay, time.UTC)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, comp.Spec.Parameters.Maintenance.DayOfWeek)
+		switch comp.Spec.Parameters.Maintenance.DayOfWeek {
+		case "tuesday":
+		case "wednesday":
+			maintTime = maintTime.Add(24 * time.Hour)
+		default:
+			assert.Failf(t, "unexpected Maintenance day", "Day: %q", comp.Spec.Parameters.Maintenance.DayOfWeek)
+		}
+
+		maintWindowStart := time.Date(0, 1, 1, 21, 0, 0, 0, time.UTC)
+		maintWindowEnd := time.Date(0, 1, 2, 5, 0, 0, 0, time.UTC)
+		assert.LessOrEqual(t, maintWindowStart, maintTime)
+		assert.LessOrEqual(t, maintTime, maintWindowEnd)
+	})
+	return maintTime
+}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/vshn/appcat-comp-functions
 
-go 1.19
+go 1.20
 
 require (
 	github.com/crossplane-contrib/provider-kubernetes v0.7.0
 	github.com/crossplane/crossplane v1.11.2
+	github.com/crossplane/crossplane-runtime v0.19.2
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.63.0
@@ -23,7 +24,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
-	github.com/crossplane/crossplane-runtime v0.19.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect

--- a/main.go
+++ b/main.go
@@ -17,6 +17,10 @@ var postgresFunctions = []runtime.Transform{
 		Name:          "user-alerting",
 		TransformFunc: vp.AddUserAlerting,
 	},
+	{
+		Name:          "random-default-schedule",
+		TransformFunc: vp.TransformSchedule,
+	},
 }
 
 func main() {

--- a/test/transforms/vshn-postgres/base.yaml
+++ b/test/transforms/vshn-postgres/base.yaml
@@ -1,0 +1,54 @@
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: FunctionIO
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        annotations:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+          - composite.apiextensions.crossplane.io
+        generateName: pgsql-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: pgsql
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: pgsql-gc9x4
+        name: pgsql-gc9x4
+      spec:
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNPostgreSQL
+          name: pgsql
+          namespace: unit-test
+        compositionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io
+        compositionRevisionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
+        compositionUpdatePolicy: Automatic
+        parameters: null
+desired:
+  composite:
+    connectionDetails: null
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+        - composite.apiextensions.crossplane.io
+        generateName: pgsql-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: pgsql
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: pgsql-gc9x4
+        name: pgsql-gc9x4
+      spec:
+        parameters: null
+        writeConnectionSecretToRef: {}
+      status: {}


### PR DESCRIPTION
Instead of providing the same default maintenance and backup time for all users, this PR will choose a random maitenance time between Tuesday 21:00 and Wednesday 5:00 and will configure backups to run daily at a hour before the maintenance start time.

i.e if we choose Tuesday 23:32 as the maintenance time, the backup will run daily at 22:32.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
