### PR TITLE
Fix alerting instance namespace missing

### DIFF
--- a/functions/vshn-postgres-func/alerting.go
+++ b/functions/vshn-postgres-func/alerting.go
@@ -30,6 +30,11 @@ func AddUserAlerting(ctx context.Context, iof *runtime.Runtime) runtime.Result {
 		return runtime.NewFatalErr(ctx, "Cannot get composite from function io", err)
 	}
 
+	// Wait for the next reconciliation in case instance namespace is missing
+	if comp.Status.InstanceNamespace == "" {
+		return runtime.NewWarning(ctx, "Composite is missing instance namespace, skipping transformation")
+	}
+
 	monitoringSpec := comp.Spec.Parameters.Monitoring
 
 	if monitoringSpec.AlertmanagerConfigRef != "" {

--- a/functions/vshn-postgres-func/alerting_test.go
+++ b/functions/vshn-postgres-func/alerting_test.go
@@ -13,6 +13,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAddUserAlerting_NoInstanceNamespace(t *testing.T) {
+	ctx := context.Background()
+	expectResult := runtime.NewWarning(ctx, "Composite is missing instance namespace, skipping transformation")
+
+	t.Run("WhenNoInstance_ThenNoErrorAndNoChanges", func(t *testing.T) {
+
+		//Given
+		io := loadRuntimeFromFile(t, "alerting/05-GivenNoStatusInstanceNamespace.yaml")
+
+		// When
+		result := AddUserAlerting(ctx, io)
+
+		// Then
+		assert.Equal(t, expectResult, result)
+	})
+}
+
 func TestAddUserAlerting(t *testing.T) {
 	ctx := context.Background()
 

--- a/test/transforms/vshn-postgres/alerting/01-GivenNoMonitoringParams.yaml
+++ b/test/transforms/vshn-postgres/alerting/01-GivenNoMonitoringParams.yaml
@@ -30,6 +30,8 @@ observed:
           name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
         compositionUpdatePolicy: Automatic
         parameters: null
+      status:
+        instanceNamespace: my-psql
 desired:
   composite:
     connectionDetails: null
@@ -51,4 +53,5 @@ desired:
       spec:
         parameters: null
         writeConnectionSecretToRef: {}
-      status: {}
+      status:
+        instanceNamespace: my-psql

--- a/test/transforms/vshn-postgres/alerting/02-GivenConfigRefNoSecretRef.yaml
+++ b/test/transforms/vshn-postgres/alerting/02-GivenConfigRefNoSecretRef.yaml
@@ -32,6 +32,8 @@ observed:
         parameters:
           monitoring:
             alertmanagerConfigRef: test
+      status:
+        instanceNamespace: my-psql
 desired:
   composite:
     connectionDetails: null
@@ -53,4 +55,5 @@ desired:
       spec:
         parameters: null
         writeConnectionSecretToRef: {}
-      status: {}
+      status:
+        instanceNamespace: my-psql

--- a/test/transforms/vshn-postgres/alerting/02-ThenExpectError.yaml
+++ b/test/transforms/vshn-postgres/alerting/02-ThenExpectError.yaml
@@ -32,6 +32,8 @@ observed:
         parameters:
           monitoring:
             alertmanagerConfigRef: test
+      status:
+        instanceNamespace: my-psql
 desired:
   composite:
     connectionDetails: null
@@ -53,4 +55,5 @@ desired:
       spec:
         parameters: null
         writeConnectionSecretToRef: {}
-      status: {}
+      status:
+        instanceNamespace: my-psql

--- a/test/transforms/vshn-postgres/alerting/05-GivenNoStatusInstanceNamespace.yaml
+++ b/test/transforms/vshn-postgres/alerting/05-GivenNoStatusInstanceNamespace.yaml
@@ -1,4 +1,39 @@
 apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: FunctionIO
+observed:
+  composite:
+    resource:
+      apiVersion: vshn.appcat.vshn.io/v1
+      kind: XVSHNPostgreSQL
+      metadata:
+        annotations:
+        creationTimestamp: "2023-03-21T16:52:31Z"
+        finalizers:
+          - composite.apiextensions.crossplane.io
+        generateName: pgsql-
+        generation: 13
+        labels:
+          appuio.io/organization: vshn
+          crossplane.io/claim-name: pgsql
+          crossplane.io/claim-namespace: unit-test
+          crossplane.io/composite: psql
+        name: psql
+      spec:
+        claimRef:
+          apiVersion: vshn.appcat.vshn.io/v1
+          kind: VSHNPostgreSQL
+          name: pgsql
+          namespace: unit-test
+        compositionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io
+        compositionRevisionRef:
+          name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
+        compositionUpdatePolicy: Automatic
+        parameters:
+          monitoring:
+            alertmanagerConfigRef: test
+            alertmanagerConfigSecretRef: test
+      status: {}
 desired:
   composite:
     connectionDetails: null
@@ -15,43 +50,9 @@ desired:
           appuio.io/organization: vshn
           crossplane.io/claim-name: pgsql
           crossplane.io/claim-namespace: unit-test
-          crossplane.io/composite: pgsql-gc9x4
-        name: pgsql-gc9x4
+          crossplane.io/composite: psql
+        name: psql
       spec:
         parameters: null
         writeConnectionSecretToRef: {}
-      status:
-        instanceNamespace: my-psql
-kind: FunctionIO
-observed:
-  composite:
-    resource:
-      apiVersion: vshn.appcat.vshn.io/v1
-      kind: XVSHNPostgreSQL
-      metadata:
-        annotations: null
-        creationTimestamp: "2023-03-21T16:52:31Z"
-        finalizers:
-        - composite.apiextensions.crossplane.io
-        generateName: pgsql-
-        generation: 13
-        labels:
-          appuio.io/organization: vshn
-          crossplane.io/claim-name: pgsql
-          crossplane.io/claim-namespace: unit-test
-          crossplane.io/composite: pgsql-gc9x4
-        name: pgsql-gc9x4
-      spec:
-        claimRef:
-          apiVersion: vshn.appcat.vshn.io/v1
-          kind: VSHNPostgreSQL
-          name: pgsql
-          namespace: unit-test
-        compositionRef:
-          name: vshnpostgres.vshn.appcat.vshn.io
-        compositionRevisionRef:
-          name: vshnpostgres.vshn.appcat.vshn.io-ce52f13
-        compositionUpdatePolicy: Automatic
-        parameters: null
-      status:
-        instanceNamespace: my-psql
+      status: {}


### PR DESCRIPTION
## Summary

* This PR will make sure the alerting function io is not executed unless instance namespace is present in status field

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [ ] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
